### PR TITLE
Consumer and Event name restrictions

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Amazon;
-using Amazon.Kinesis;
+﻿using Microsoft.Extensions.Options;
 using System;
 using Tingle.EventBus.Transports.Amazon.Kinesis;
 
@@ -25,38 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // Configure the options for Amazon Kinesis
             services.Configure(configure);
-            services.PostConfigure<AmazonKinesisTransportOptions>(options =>
-            {
-                // Ensure the region is provided
-                if (string.IsNullOrWhiteSpace(options.RegionName) && options.Region == null)
-                {
-                    throw new InvalidOperationException($"Either '{nameof(options.RegionName)}' or '{nameof(options.Region)}' must be provided");
-                }
-
-                options.Region ??= RegionEndpoint.GetBySystemName(options.RegionName);
-
-                // Ensure the access key is specified
-                if (string.IsNullOrWhiteSpace(options.AccessKey))
-                {
-                    throw new InvalidOperationException($"The '{nameof(options.AccessKey)}' must be provided");
-                }
-
-                // Ensure the secret is specified
-                if (string.IsNullOrWhiteSpace(options.SecretKey))
-                {
-                    throw new InvalidOperationException($"The '{nameof(options.SecretKey)}' must be provided");
-                }
-
-                // Ensure we have options for Kinesis and the region is set
-                options.KinesisConfig ??= new AmazonKinesisConfig();
-                options.KinesisConfig.RegionEndpoint ??= options.Region;
-
-                // Ensure the partition key resolver is set
-                if (options.PartitionKeyResolver == null)
-                {
-                    throw new InvalidOperationException($"The '{nameof(options.PartitionKeyResolver)}' must be provided");
-                }
-            });
+            services.AddSingleton<IPostConfigureOptions<AmazonKinesisTransportOptions>, AmazonKinesisPostConfigureOptions>();
 
             // Register the transport
             builder.AddTransport<AmazonKinesisTransport, AmazonKinesisTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsPostConfigureOptions.cs
@@ -1,0 +1,75 @@
+﻿using Amazon;
+using Amazon.SimpleNotificationService;
+using Amazon.SQS;
+using Microsoft.Extensions.Options;
+using System;
+using Tingle.EventBus;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A class to finish the configuration of instances of <see cref="AmazonSqsTransportOptions"/>.
+    /// </summary>
+    internal class AmazonSqsPostConfigureOptions : IPostConfigureOptions<AmazonSqsTransportOptions>
+    {
+        private readonly EventBusOptions busOptions;
+
+        public AmazonSqsPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+        {
+            busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
+        }
+
+        public void PostConfigure(string name, AmazonSqsTransportOptions options)
+        {
+            // ensure the region is provided
+            if (string.IsNullOrWhiteSpace(options.RegionName) && options.Region == null)
+            {
+                throw new InvalidOperationException($"Either '{nameof(options.RegionName)}' or '{nameof(options.Region)}' must be provided");
+            }
+
+            options.Region ??= RegionEndpoint.GetBySystemName(options.RegionName);
+
+            // ensure the access key is specified
+            if (string.IsNullOrWhiteSpace(options.AccessKey))
+            {
+                throw new InvalidOperationException($"The '{nameof(options.AccessKey)}' must be provided");
+            }
+
+            // ensure the secret is specified
+            if (string.IsNullOrWhiteSpace(options.SecretKey))
+            {
+                throw new InvalidOperationException($"The '{nameof(options.SecretKey)}' must be provided");
+            }
+
+            // ensure we have options for SQS and SNS and their regions are set
+            options.SqsConfig ??= new AmazonSQSConfig();
+            options.SqsConfig.RegionEndpoint ??= options.Region;
+            options.SnsConfig ??= new AmazonSimpleNotificationServiceConfig();
+            options.SnsConfig.RegionEndpoint ??= options.Region;
+
+            // Ensure the entity names are not longer than the limits
+            var registrations = busOptions.GetRegistrations(TransportNames.AmazonSqs);
+            foreach (var ereg in registrations)
+            {
+                // Event names become Topic names and they should not be longer than 256 characters
+                // See https://aws.amazon.com/sns/faqs/#:~:text=Features%20and%20functionality,and%20underscores%20(_)%20are%20allowed.
+                if (ereg.EventName.Length > 256)
+                {
+                    throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
+                                                       + "Amazon SNS does not allow more than 256 characters for Topic names.");
+                }
+
+                // Consumer names become Queue names and they should not be longer than 80 characters
+                // See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
+                foreach (var creg in ereg.Consumers)
+                {
+                    if (creg.ConsumerName.Length > 80)
+                    {
+                        throw new InvalidOperationException($"ConsumerName '{creg.ConsumerName}' generated from '{creg.ConsumerType.Name}' is too long. "
+                                                           + "Amazon SQS does not allow more than 80 characters for Queue names.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Amazon;
-using Amazon.SimpleNotificationService;
-using Amazon.SQS;
+﻿using Microsoft.Extensions.Options;
 using System;
 using Tingle.EventBus.Transports.Amazon.Sqs;
 
@@ -26,34 +24,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
             // configure the options for Amazon SQS and SNS option
             services.Configure(configure);
-            services.PostConfigure<AmazonSqsTransportOptions>(options =>
-            {
-                // ensure the region is provided
-                if (string.IsNullOrWhiteSpace(options.RegionName) && options.Region == null)
-                {
-                    throw new InvalidOperationException($"Either '{nameof(options.RegionName)}' or '{nameof(options.Region)}' must be provided");
-                }
-
-                options.Region ??= RegionEndpoint.GetBySystemName(options.RegionName);
-
-                // ensure the access key is specified
-                if (string.IsNullOrWhiteSpace(options.AccessKey))
-                {
-                    throw new InvalidOperationException($"The '{nameof(options.AccessKey)}' must be provided");
-                }
-
-                // ensure the secret is specified
-                if (string.IsNullOrWhiteSpace(options.SecretKey))
-                {
-                    throw new InvalidOperationException($"The '{nameof(options.SecretKey)}' must be provided");
-                }
-
-                // ensure we have options for SQS and SNS and their regions are set
-                options.SqsConfig ??= new AmazonSQSConfig();
-                options.SqsConfig.RegionEndpoint ??= options.Region;
-                options.SnsConfig ??= new AmazonSimpleNotificationServiceConfig();
-                options.SnsConfig.RegionEndpoint ??= options.Region;
-            });
+            services.AddSingleton<IPostConfigureOptions<AmazonSqsTransportOptions>, AmazonSqsPostConfigureOptions>();
 
             // register the transport
             builder.AddTransport<AmazonSqsTransport, AmazonSqsTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
@@ -19,13 +19,13 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public void PostConfigure(string name, AzureEventHubsTransportOptions options)
         {
-            // ensure the connection string
+            // Ensure the connection string
             if (string.IsNullOrWhiteSpace(options.ConnectionString))
             {
                 throw new InvalidOperationException($"The '{nameof(options.ConnectionString)}' must be provided");
             }
 
-            // if there are consumers for this transport, we must check azure blob storage
+            // If there are consumers for this transport, we must check azure blob storage
             var registrations = busOptions.GetRegistrations(TransportNames.AzureEventHubs);
             if (registrations.Any(r => r.Consumers.Count > 0))
             {

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
@@ -44,6 +44,28 @@ namespace Microsoft.Extensions.DependencyInjection
                 // ensure the prefix is always lower case.
                 options.BlobContainerName = options.BlobContainerName.ToLower();
             }
+
+            // Ensure the entity names are not longer than the limits
+            // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
+            foreach (var ereg in registrations)
+            {
+                // Event names become Event Hub names and they should not be longer than 256 characters
+                if (ereg.EventName.Length > 256)
+                {
+                    throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
+                                                       + "Azure Event Hubs does not allow more than 256 characters for Event Hub names.");
+                }
+
+                // Consumer names become Consumer Group names and they should not be longer than 256 characters
+                foreach (var creg in ereg.Consumers)
+                {
+                    if (creg.ConsumerName.Length > 256)
+                    {
+                        throw new InvalidOperationException($"ConsumerName '{creg.ConsumerName}' generated from '{creg.ConsumerType.Name}' is too long. "
+                                                           + "Azure Event Hubs does not allow more than 256 characters for Consumer Group names.");
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStoragePostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStoragePostConfigureOptions.cs
@@ -19,19 +19,31 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public void PostConfigure(string name, AzureQueueStorageTransportOptions options)
         {
-            // ensure the connection string
+            // Ensure the connection string
             if (string.IsNullOrWhiteSpace(options.ConnectionString))
             {
                 throw new InvalidOperationException($"The '{nameof(options.ConnectionString)}' must be provided");
             }
 
-            // ensure there's only one consumer per event
+            // Ensure there's only one consumer per event
             var registrations = busOptions.GetRegistrations(TransportNames.AzureQueueStorage);
             var multiple = registrations.FirstOrDefault(r => r.Consumers.Count > 1);
             if (multiple != null)
             {
                 throw new InvalidOperationException($"More than one consumer registered for '{multiple.EventType.Name}' yet "
                                                    + "Azure Queue Storage does not support more than one consumer per event in the same application domain.");
+            }
+
+            // Ensure the entity names are not longer than the limits
+            // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata#queue-names
+            foreach (var ereg in registrations)
+            {
+                // Event names become topic names and they should not be longer than 63 characters
+                if (ereg.EventName.Length > 63)
+                {
+                    throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
+                                                       + "Azure Queue Storage does not allow more than 63 characters for Queue names.");
+                }
             }
         }
     }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
@@ -28,10 +28,10 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.AzureServiceBus);
             foreach (var ereg in registrations)
             {
-                if (ereg.EventName.Length > 50)
+                if (ereg.EventName.Length > 260)
                 {
                     throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
-                                                       + "Azure Service Bus does not allow more than 50 characters.");
+                                                       + "Azure Service Bus does not allow more than 260 characters for topics and queues.");
                 }
 
                 foreach (var creg in ereg.Consumers)
@@ -39,7 +39,7 @@ namespace Microsoft.Extensions.DependencyInjection
                     if (creg.ConsumerName.Length > 50)
                     {
                         throw new InvalidOperationException($"ConsumerName '{creg.ConsumerName}' generated from '{creg.ConsumerType.Name}' is too long. "
-                                                           + "Azure Service Bus does not allow more than 50 characters.");
+                                                           + "Azure Service Bus does not allow more than 50 characters for subscriptions.");
                     }
                 }
             }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
@@ -29,14 +29,14 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.AzureServiceBus);
             foreach (var ereg in registrations)
             {
-                // Event names become topic names and they should not be longer than 260 characters
+                // Event names become Topic and Queue names and they should not be longer than 260 characters
                 if (ereg.EventName.Length > 260)
                 {
                     throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
                                                        + "Azure Service Bus does not allow more than 260 characters for Topic and Queue names.");
                 }
 
-                // Consumer names become subscription names and they should not be longer than 50 characters
+                // Consumer names become Subscription names and they should not be longer than 50 characters
                 foreach (var creg in ereg.Consumers)
                 {
                     if (creg.ConsumerName.Length > 50)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
@@ -18,28 +18,31 @@ namespace Microsoft.Extensions.DependencyInjection
 
         public void PostConfigure(string name, AzureServiceBusTransportOptions options)
         {
-            // ensure the connection string is not null
+            // Ensure the connection string is not null
             if (string.IsNullOrWhiteSpace(options.ConnectionString))
             {
                 throw new InvalidOperationException($"The '{nameof(options.ConnectionString)}' must be provided");
             }
 
-            // ensure the entity names are not longer than 50 characters
+            // Ensure the entity names are not longer than the limits
+            // See https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas#messaging-quotas
             var registrations = busOptions.GetRegistrations(TransportNames.AzureServiceBus);
             foreach (var ereg in registrations)
             {
+                // Event names become topic names and they should not be longer than 260 characters
                 if (ereg.EventName.Length > 260)
                 {
                     throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
-                                                       + "Azure Service Bus does not allow more than 260 characters for topics and queues.");
+                                                       + "Azure Service Bus does not allow more than 260 characters for Topic and Queue names.");
                 }
 
+                // Consumer names become subscription names and they should not be longer than 50 characters
                 foreach (var creg in ereg.Consumers)
                 {
                     if (creg.ConsumerName.Length > 50)
                     {
                         throw new InvalidOperationException($"ConsumerName '{creg.ConsumerName}' generated from '{creg.ConsumerType.Name}' is too long. "
-                                                           + "Azure Service Bus does not allow more than 50 characters for subscriptions.");
+                                                           + "Azure Service Bus does not allow more than 50 characters for Subscription names.");
                     }
                 }
             }

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaPostConfigureOptions.cs
@@ -54,6 +54,29 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new InvalidOperationException($"More than one consumer registered for '{multiple.EventType.Name}' yet "
                                                    + "Kafka does not support more than one consumer per event in the same application domain.");
             }
+
+            // Ensure the entity names are not longer than the limits
+            // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
+            foreach (var ereg in registrations)
+            {
+                // Event names become Topic names and they should not be longer than 255 characters
+                // https://www.ibm.com/support/knowledgecenter/SSMKHH_10.0.0/com.ibm.etools.mft.doc/bz91041_.html
+                if (ereg.EventName.Length > 255)
+                {
+                    throw new InvalidOperationException($"EventName '{ereg.EventName}' generated from '{ereg.EventType.Name}' is too long. "
+                                                       + "Kafka does not allow more than 255 characters for Topic names.");
+                }
+
+                // Consumer names become Consumer Group IDs and they should not be longer than 255 characters
+                foreach (var creg in ereg.Consumers)
+                {
+                    if (creg.ConsumerName.Length > 255)
+                    {
+                        throw new InvalidOperationException($"ConsumerName '{creg.ConsumerName}' generated from '{creg.ConsumerType.Name}' is too long. "
+                                                           + "Kafka does not allow more than 255 characters for Consumer Group IDs.");
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Tingle.EventBus/ConsumerNameSource.cs
+++ b/src/Tingle.EventBus/ConsumerNameSource.cs
@@ -16,8 +16,20 @@
         ApplicationName,
 
         /// <summary>
-        /// The name of the application and the consumer are combined.
+        /// The name of the application
+        /// and the type name of the consumer are combined.
         /// </summary>
         ApplicationAndTypeName,
+
+        /// <summary>
+        /// The prefix provided in the bus options.
+        /// </summary>
+        Prefix,
+
+        /// <summary>
+        /// The prefix provided in the bus options
+        /// and the type name of the consumer are cmobined.
+        /// </summary>
+        PrefixAndTypeName,
     }
 }

--- a/src/Tingle.EventBus/ConsumerNameSource.cs
+++ b/src/Tingle.EventBus/ConsumerNameSource.cs
@@ -11,17 +11,6 @@
         TypeName,
 
         /// <summary>
-        /// The name of the hosting application is used.
-        /// </summary>
-        ApplicationName,
-
-        /// <summary>
-        /// The name of the application
-        /// and the type name of the consumer are combined.
-        /// </summary>
-        ApplicationAndTypeName,
-
-        /// <summary>
         /// The prefix provided in the bus options.
         /// </summary>
         Prefix,

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -23,9 +23,11 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             Services = services ?? throw new ArgumentNullException(nameof(services));
 
+            // Configure the options
+            Services.AddSingleton<IConfigureOptions<EventBusOptions>, EventBusConfigureOptions>();
             Services.AddSingleton<IPostConfigureOptions<EventBusOptions>, EventBusPostConfigureOptions>();
 
-            // register necessary services
+            // Register necessary services
             Services.AddTransient<IEventPublisher, EventPublisher>();
             Services.AddSingleton<EventBus>();
             Services.AddHostedService(p => p.GetRequiredService<EventBus>());

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -24,6 +24,11 @@ namespace Microsoft.Extensions.DependencyInjection
             Services = services ?? throw new ArgumentNullException(nameof(services));
 
             Services.AddSingleton<IPostConfigureOptions<EventBusOptions>, EventBusPostConfigureOptions>();
+
+            // register necessary services
+            Services.AddTransient<IEventPublisher, EventPublisher>();
+            Services.AddSingleton<EventBus>();
+            Services.AddHostedService(p => p.GetRequiredService<EventBus>());
         }
 
         /// <summary>

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -2,6 +2,7 @@
 using Microsoft.Extensions.Options;
 using System;
 using Tingle.EventBus;
+using Tingle.EventBus.Serialization;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -22,6 +23,21 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             // Set the default ConsumerNamePrefix
             options.ConsumerNamePrefix ??= environment.ApplicationName;
+
+            // Setup HostInfo
+            if (options.HostInfo == null)
+            {
+                var entry = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
+                options.HostInfo = new HostInfo
+                {
+                    ApplicationName = environment.ApplicationName,
+                    ApplicationVersion = entry.GetName().Version.ToString(),
+                    EnvironmentName = environment.EnvironmentName,
+                    LibraryVersion = typeof(EventBus).Assembly.GetName().Version.ToString(),
+                    MachineName = Environment.MachineName,
+                    OperatingSystem = Environment.OSVersion.ToString(),
+                };
+            }
         }
     }
 }

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using System;
+using Tingle.EventBus;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A class to finish configure non-trivial defaults of instances of <see cref="EventBusOptions"/>.
+    /// </summary>
+    internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>
+    {
+        private readonly IHostEnvironment environment;
+
+        public EventBusConfigureOptions(IHostEnvironment environment)
+        {
+            this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
+        }
+
+        /// <inheritdoc/>
+        public void Configure(EventBusOptions options)
+        {
+            // Set the default ConsumerNamePrefix
+            options.ConsumerNamePrefix ??= environment.ApplicationName;
+        }
+    }
+}

--- a/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Extensions.DependencyInjection
             this.environment = environment ?? throw new ArgumentNullException(nameof(environment));
         }
 
+        /// <inheritdoc/>
         public void PostConfigure(string name, EventBusOptions options)
         {
             // check bounds for startup delay, if provided

--- a/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
@@ -81,6 +81,13 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
+            // if the ConsumerNameSource is Prefix or requires the prefix, ensure it is set
+            if ((options.ConsumerNameSource == ConsumerNameSource.Prefix || options.ConsumerNameSource == ConsumerNameSource.PrefixAndTypeName)
+                && string.IsNullOrWhiteSpace(options.ConsumerNamePrefix))
+            {
+                throw new InvalidOperationException($"'{options.ConsumerNamePrefix}' when using {nameof(ConsumerNameSource)}.{options.ConsumerNameSource}");
+            }
+
             // setup names and transports for each event and its consumers
             var registrations = options.Registrations.Values.ToList();
             foreach (var evr in registrations)

--- a/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
@@ -72,13 +72,6 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            // If the ConsumerNameSource is Prefix or requires the prefix, ensure it is set
-            if ((options.ConsumerNameSource == ConsumerNameSource.Prefix || options.ConsumerNameSource == ConsumerNameSource.PrefixAndTypeName)
-                && string.IsNullOrWhiteSpace(options.ConsumerNamePrefix))
-            {
-                throw new InvalidOperationException($"'{nameof(options.ConsumerNamePrefix)}' when using {nameof(ConsumerNameSource)}.{options.ConsumerNameSource}");
-            }
-
             // Setup names and transports for each event and its consumers
             var registrations = options.Registrations.Values.ToList();
             foreach (var evr in registrations)

--- a/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
@@ -4,7 +4,6 @@ using System;
 using System.Linq;
 using Tingle.EventBus;
 using Tingle.EventBus.Registrations;
-using Tingle.EventBus.Serialization;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -23,7 +22,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <inheritdoc/>
         public void PostConfigure(string name, EventBusOptions options)
         {
-            // check bounds for startup delay, if provided
+            // Check bounds for startup delay, if provided
             if (options.StartupDelay != null)
             {
                 var ticks = options.StartupDelay.Value.Ticks;
@@ -32,7 +31,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.StartupDelay = TimeSpan.FromTicks(ticks);
             }
 
-            // check bounds for duplicate detection duration, if duplicate detection is enabled
+            // Check bounds for duplicate detection duration, if duplicate detection is enabled
             if (options.EnableDeduplication)
             {
                 var ticks = options.DuplicateDetectionDuration.Ticks;
@@ -41,28 +40,19 @@ namespace Microsoft.Extensions.DependencyInjection
                 options.DuplicateDetectionDuration = TimeSpan.FromTicks(ticks);
             }
 
-            // setup HostInfo
+            // Ensure we have HostInfo set
             if (options.HostInfo == null)
             {
-                var entry = System.Reflection.Assembly.GetEntryAssembly() ?? System.Reflection.Assembly.GetCallingAssembly();
-                options.HostInfo = new HostInfo
-                {
-                    ApplicationName = environment.ApplicationName,
-                    ApplicationVersion = entry.GetName().Version.ToString(),
-                    EnvironmentName = environment.EnvironmentName,
-                    LibraryVersion = typeof(EventBus).Assembly.GetName().Version.ToString(),
-                    MachineName = Environment.MachineName,
-                    OperatingSystem = Environment.OSVersion.ToString(),
-                };
+                throw new InvalidOperationException($"'{nameof(options.HostInfo)}' must be set.");
             }
 
-            // ensure there is at least one registered transport
+            // Ensure there is at least one registered transport
             if (options.RegisteredTransportNames.Count == 0)
             {
-                throw new InvalidOperationException("There must be at least one registered transport");
+                throw new InvalidOperationException("There must be at least one registered transport.");
             }
 
-            // if the default transport name has been set, ensure it is registered
+            // If the default transport name has been set, ensure it is registered
             if (!string.IsNullOrWhiteSpace(options.DefaultTransportName))
             {
                 // ensure the transport name set has been registered
@@ -73,7 +63,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            // if the default transport name has not been set, and there is only one registered, set it as default
+            // If the default transport name has not been set, and there is only one registered, set it as default
             if (string.IsNullOrWhiteSpace(options.DefaultTransportName))
             {
                 if (options.RegisteredTransportNames.Count == 1)
@@ -82,14 +72,14 @@ namespace Microsoft.Extensions.DependencyInjection
                 }
             }
 
-            // if the ConsumerNameSource is Prefix or requires the prefix, ensure it is set
+            // If the ConsumerNameSource is Prefix or requires the prefix, ensure it is set
             if ((options.ConsumerNameSource == ConsumerNameSource.Prefix || options.ConsumerNameSource == ConsumerNameSource.PrefixAndTypeName)
                 && string.IsNullOrWhiteSpace(options.ConsumerNamePrefix))
             {
-                throw new InvalidOperationException($"'{options.ConsumerNamePrefix}' when using {nameof(ConsumerNameSource)}.{options.ConsumerNameSource}");
+                throw new InvalidOperationException($"'{nameof(options.ConsumerNamePrefix)}' when using {nameof(ConsumerNameSource)}.{options.ConsumerNameSource}");
             }
 
-            // setup names and transports for each event and its consumers
+            // Setup names and transports for each event and its consumers
             var registrations = options.Registrations.Values.ToList();
             foreach (var evr in registrations)
             {
@@ -99,7 +89,7 @@ namespace Microsoft.Extensions.DependencyInjection
                    .SetConsumerNames(options, environment); // set the consumer names
             }
 
-            // ensure there are no events with the same name
+            // Ensure there are no events with the same name
             var conflicted = registrations.GroupBy(r => r.EventName).FirstOrDefault(kvp => kvp.Count() > 1);
             if (conflicted != null)
             {
@@ -108,9 +98,9 @@ namespace Microsoft.Extensions.DependencyInjection
                                                   + $" Types:\r\n- {string.Join("\r\n- ", names)}");
             }
 
+            // Ensure there are no consumers with the same name per event
             foreach (var evr in registrations)
             {
-                // ensure there are no consumers with the same name per event
                 var conflict = evr.Consumers.GroupBy(ecr => ecr.ConsumerName).FirstOrDefault(kvp => kvp.Count() > 1);
                 if (conflict != null)
                 {

--- a/src/Tingle.EventBus/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/IServiceCollectionExtensions.cs
@@ -11,14 +11,26 @@ namespace Microsoft.Extensions.DependencyInjection
         /// Add Event Bus services.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> instance to add services to.</param>
+        /// <returns>An <see cref="EventBusBuilder"/> to continue setting up the Event Bus.</returns>
+        public static EventBusBuilder AddEventBus(this IServiceCollection services)
+        {
+            if (services == null) throw new ArgumentNullException(nameof(services));
+
+            return new EventBusBuilder(services)
+                .UseDefaultSerializer();
+        }
+
+        /// <summary>
+        /// Add Event Bus services.
+        /// </summary>
+        /// <param name="services">The <see cref="IServiceCollection"/> instance to add services to.</param>
         /// <param name="setupAction">An optional action for setting up the bus.</param>
         /// <returns></returns>
         public static IServiceCollection AddEventBus(this IServiceCollection services, Action<EventBusBuilder> setupAction = null)
         {
             if (services == null) throw new ArgumentNullException(nameof(services));
 
-            var builder = new EventBusBuilder(services)
-                .UseDefaultSerializer();
+            var builder = services.AddEventBus();
 
             setupAction?.Invoke(builder);
 

--- a/src/Tingle.EventBus/DependencyInjection/IServiceCollectionExtensions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/IServiceCollectionExtensions.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Tingle.EventBus;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -9,25 +8,17 @@ namespace Microsoft.Extensions.DependencyInjection
     public static class IServiceCollectionExtensions
     {
         /// <summary>
-        /// Add Event bus services.
+        /// Add Event Bus services.
         /// </summary>
         /// <param name="services">The <see cref="IServiceCollection"/> instance to add services to.</param>
         /// <param name="setupAction">An optional action for setting up the bus.</param>
         /// <returns></returns>
         public static IServiceCollection AddEventBus(this IServiceCollection services, Action<EventBusBuilder> setupAction = null)
         {
-            if (services == null)
-            {
-                throw new ArgumentNullException(nameof(services));
-            }
+            if (services == null) throw new ArgumentNullException(nameof(services));
 
             var builder = new EventBusBuilder(services)
                 .UseDefaultSerializer();
-
-            // register necessary services
-            services.AddTransient<IEventPublisher, EventPublisher>();
-            services.AddSingleton<EventBus>();
-            services.AddHostedService(p => p.GetRequiredService<EventBus>());
 
             setupAction?.Invoke(builder);
 

--- a/src/Tingle.EventBus/EventBusOptions.cs
+++ b/src/Tingle.EventBus/EventBusOptions.cs
@@ -70,8 +70,8 @@ namespace Tingle.EventBus
         /// <summary>
         /// The source used to generate names for consumers.
         /// Some transports are versy sensitive to the value used here and thus should be used carefully.
-        /// When set to <see cref="ConsumerNameSource.ApplicationName"/>, each subscription/exchange will
-        /// be named the same as the application before appending the event name.
+        /// When set to <see cref="ConsumerNameSource.Prefix"/>, each subscription/exchange will
+        /// be named the same as <see cref="ConsumerNamePrefix"/> before appending the event name.
         /// For applications with more than one consumer per event type, use <see cref="ConsumerNameSource.TypeName"/>
         /// to avoid duplicates.
         /// Defaults to <see cref="ConsumerNameSource.TypeName"/>.

--- a/src/Tingle.EventBus/EventBusOptions.cs
+++ b/src/Tingle.EventBus/EventBusOptions.cs
@@ -79,6 +79,11 @@ namespace Tingle.EventBus
         public ConsumerNameSource ConsumerNameSource { get; set; } = ConsumerNameSource.TypeName;
 
         /// <summary>
+        /// The prefix used with <see cref="ConsumerNameSource.Prefix"/> and <see cref="ConsumerNameSource.PrefixAndTypeName"/>.
+        /// </summary>
+        public string ConsumerNamePrefix { get; set; }
+
+        /// <summary>
         /// The information about the host where the EventBus is running.
         /// </summary>
         internal HostInfo HostInfo { get; set; }

--- a/src/Tingle.EventBus/EventBusOptions.cs
+++ b/src/Tingle.EventBus/EventBusOptions.cs
@@ -80,6 +80,7 @@ namespace Tingle.EventBus
 
         /// <summary>
         /// The prefix used with <see cref="ConsumerNameSource.Prefix"/> and <see cref="ConsumerNameSource.PrefixAndTypeName"/>.
+        /// Defaults to <see cref="Microsoft.Extensions.Hosting.IHostEnvironment.ApplicationName"/>.
         /// </summary>
         public string ConsumerNamePrefix { get; set; }
 

--- a/src/Tingle.EventBus/Extensions/RegistrationExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/RegistrationExtensions.cs
@@ -55,6 +55,9 @@ namespace Tingle.EventBus.Registrations
                 throw new InvalidOperationException($"The {nameof(reg.EventName)} for must be set before setting names of the consumer.");
             }
 
+            // prefix is either the one provided or the application name
+            var prefix = options.ConsumerNamePrefix ?? environment.ApplicationName;
+
             foreach (var creg in reg.Consumers)
             {
                 // set the consumer name, if not set
@@ -70,10 +73,8 @@ namespace Tingle.EventBus.Registrations
                         cname = options.ConsumerNameSource switch
                         {
                             ConsumerNameSource.TypeName => typeName,
-                            ConsumerNameSource.ApplicationName => environment.ApplicationName,
-                            ConsumerNameSource.ApplicationAndTypeName => $"{environment.ApplicationName}.{typeName}",
-                            ConsumerNameSource.Prefix => options.ConsumerNamePrefix,
-                            ConsumerNameSource.PrefixAndTypeName => $"{options.ConsumerNamePrefix}.{typeName}",
+                            ConsumerNameSource.Prefix => prefix,
+                            ConsumerNameSource.PrefixAndTypeName => $"{prefix}.{typeName}",
                             _ => throw new InvalidOperationException($"'{nameof(options.ConsumerNameSource)}.{options.ConsumerNameSource}' is not supported"),
                         };
                         cname = ApplyNamingConvention(cname, options.NamingConvention);

--- a/src/Tingle.EventBus/Extensions/RegistrationExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/RegistrationExtensions.cs
@@ -72,6 +72,8 @@ namespace Tingle.EventBus.Registrations
                             ConsumerNameSource.TypeName => typeName,
                             ConsumerNameSource.ApplicationName => environment.ApplicationName,
                             ConsumerNameSource.ApplicationAndTypeName => $"{environment.ApplicationName}.{typeName}",
+                            ConsumerNameSource.Prefix => options.ConsumerNamePrefix,
+                            ConsumerNameSource.PrefixAndTypeName => $"{options.ConsumerNamePrefix}.{typeName}",
                             _ => throw new InvalidOperationException($"'{nameof(options.ConsumerNameSource)}.{options.ConsumerNameSource}' is not supported"),
                         };
                         cname = ApplyNamingConvention(cname, options.NamingConvention);

--- a/tests/Tingle.EventBus.Tests/RegistrationExtensionsTests.cs
+++ b/tests/Tingle.EventBus.Tests/RegistrationExtensionsTests.cs
@@ -102,12 +102,21 @@ namespace Tingle.EventBus.Tests
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "app1_test_event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1-test-event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "app1_test_consumer1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-test-consumer1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_test_consumer1_test_event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationName, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-test-event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_test_event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
         [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
+        // overriden by attribute
         [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
         [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
         [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
@@ -119,9 +128,10 @@ namespace Tingle.EventBus.Tests
             var environment = new FakeHostEnvironment("app1");
             var options = new EventBusOptions
             {
-                UseFullTypeNames = useFullTypeNames,
-                ConsumerNameSource = consumerNameSource,
                 NamingConvention = namingConvention,
+                UseFullTypeNames = useFullTypeNames,
+                ConsumerNamePrefix = "service1",
+                ConsumerNameSource = consumerNameSource,
             };
 
             var registration = new EventRegistration(eventType);

--- a/tests/Tingle.EventBus.Tests/RegistrationExtensionsTests.cs
+++ b/tests/Tingle.EventBus.Tests/RegistrationExtensionsTests.cs
@@ -96,41 +96,44 @@ namespace Tingle.EventBus.Tests
         }
 
         [Theory]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "test_consumer1_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationName, NamingConvention.KebabCase, "app1-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "app1_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "app1_test_consumer1_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-test-consumer1-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_test_consumer1_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationName, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
-        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "test_consumer1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "app1_test_consumer1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-test-consumer1-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_test_consumer1_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
+            "app1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase,
+            "app1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
+            "service1-tingle-event-bus-tests-test-consumer1-tingle-event-bus-tests-test-event1")]
+        [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_test_consumer1_tingle_event_bus_tests_test_event1")]
         // overriden by attribute
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.ApplicationName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, ConsumerNameSource.ApplicationName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, ConsumerNameSource.ApplicationAndTypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-        public void SetConsumerName_Works(Type eventType, Type consumerType, bool useFullTypeNames, ConsumerNameSource consumerNameSource, NamingConvention namingConvention, string expected)
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "sample-consumer-sample-event")]
+        [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
+        public void SetConsumerName_Works(Type eventType, Type consumerType, bool useFullTypeNames, string prefix, ConsumerNameSource consumerNameSource, NamingConvention namingConvention, string expected)
         {
             var environment = new FakeHostEnvironment("app1");
             var options = new EventBusOptions
             {
                 NamingConvention = namingConvention,
                 UseFullTypeNames = useFullTypeNames,
-                ConsumerNamePrefix = "service1",
+                ConsumerNamePrefix = prefix,
                 ConsumerNameSource = consumerNameSource,
             };
 


### PR DESCRIPTION
Each transport has different limits on the length of the names of its entities. Rather than fail during publish or on startup of consumers, check the lengths instances of `IPostConfigureOptions<T>` for each transport.
As a consequence of name restrictions, `ConsumerNameSource.AppliccationName` and `ConsumerNameSource.ApplicationAndTypeName` are renamed to `Prefix` and `PrefixAndTypeName` respecitively so that prefixes can be overriden but defaulted to the `IHostEvironment.ApplicationName`