### PR TITLE
Default entity options

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransportOptions.cs
@@ -4,6 +4,7 @@ using Amazon.SQS;
 using Amazon.SQS.Model;
 using System;
 using Tingle.EventBus;
+using Tingle.EventBus.Registrations;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -29,12 +30,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A setup function for setting up settings for a topic.
         /// This is only called before creation.
         /// </summary>
-        public Action<CreateTopicRequest> SetupCreateTopicRequest { get; set; }
+        public Action<EventRegistration, CreateTopicRequest> SetupCreateTopicRequest { get; set; }
 
         /// <summary>
         /// A setup function for setting up settings for a queue.
         /// This is only called before creation.
         /// </summary>
-        public Action<CreateQueueRequest> SetupCreateQueueRequest { get; set; }
+        public Action<EventConsumerRegistration, CreateQueueRequest> SetupCreateQueueRequest { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -263,7 +263,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                     };
 
                     // Allow for the defaults to be overriden
-                    TransportOptions.CreateProducerClientOptions?.Invoke(reg, epco);
+                    TransportOptions.SetupProducerClientOptions?.Invoke(reg, epco);
 
                     // Override values that must be overriden
 
@@ -324,7 +324,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                     };
 
                     // Allow for the defaults to be overriden
-                    TransportOptions.CreateProcessorClientOptions?.Invoke(creg, epco);
+                    TransportOptions.SetupProcessorClientOptions?.Invoke(ereg, creg, epco);
 
                     // How to ensure consumer is created in the event hub?
                     // EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager which need different credentials

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -254,7 +254,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                     if (deadletter) name += TransportOptions.DeadLetterSuffix;
 
                     // Create the producer options
-                    var epco = TransportOptions.CreateProducerClientOptions?.Invoke() ?? new EventHubProducerClientOptions();
+                    var epco = TransportOptions.CreateProducerClientOptions?.Invoke(reg) ?? new EventHubProducerClientOptions();
 
                     // Override values that must be overriden
                     epco.ConnectionOptions ??= new EventHubConnectionOptions();
@@ -309,7 +309,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                                                                       blobContainerName: TransportOptions.BlobContainerName);
 
                     // Create the procesor client options
-                    var epco = TransportOptions.CreateProcessorClientOptions?.Invoke() ?? new EventProcessorClientOptions();
+                    var epco = TransportOptions.CreateProcessorClientOptions?.Invoke(creg) ?? new EventProcessorClientOptions();
 
                     // Override values that must be overriden
                     epco.ConnectionOptions ??= new EventHubConnectionOptions();

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -254,20 +254,26 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                     if (deadletter) name += TransportOptions.DeadLetterSuffix;
 
                     // Create the producer options
-                    var epco = TransportOptions.CreateProducerClientOptions?.Invoke(reg) ?? new EventHubProducerClientOptions();
+                    var epco = new EventHubProducerClientOptions
+                    {
+                        ConnectionOptions = new EventHubConnectionOptions
+                        {
+                            TransportType = TransportOptions.TransportType,
+                        },
+                    };
+
+                    // Allow for the defaults to be overriden
+                    TransportOptions.CreateProducerClientOptions?.Invoke(reg, epco);
 
                     // Override values that must be overriden
-                    epco.ConnectionOptions ??= new EventHubConnectionOptions();
-                    epco.ConnectionOptions.TransportType = TransportOptions.TransportType;
 
                     // Create the producer
                     producer = new EventHubProducerClient(connectionString: TransportOptions.ConnectionString,
                                                           eventHubName: name,
                                                           clientOptions: epco);
 
-                    // ensure event hub is created
-
-                    // EventHubs can only be create via Azure portal or using Resource Manager which needs different credentials
+                    // How to ensure event hub is created?
+                    // EventHubs can only be create via Azure portal or using Resource Manager which need different credentials
 
                     producersCache[(reg.EventType, deadletter)] = producer;
                 }
@@ -308,12 +314,20 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                     var blobContainerClient = new BlobContainerClient(connectionString: TransportOptions.BlobStorageConnectionString,
                                                                       blobContainerName: TransportOptions.BlobContainerName);
 
-                    // Create the procesor client options
-                    var epco = TransportOptions.CreateProcessorClientOptions?.Invoke(creg) ?? new EventProcessorClientOptions();
+                    // Create the processor client options
+                    var epco = new EventProcessorClientOptions
+                    {
+                        ConnectionOptions = new EventHubConnectionOptions
+                        {
+                            TransportType = TransportOptions.TransportType,
+                        },
+                    };
 
-                    // Override values that must be overriden
-                    epco.ConnectionOptions ??= new EventHubConnectionOptions();
-                    epco.ConnectionOptions.TransportType = TransportOptions.TransportType;
+                    // Allow for the defaults to be overriden
+                    TransportOptions.CreateProcessorClientOptions?.Invoke(creg, epco);
+
+                    // How to ensure consumer is created in the event hub?
+                    // EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager which need different credentials
 
                     // Create the processor
                     processor = new EventProcessorClient(checkpointStore: blobContainerClient,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
@@ -57,12 +57,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A function to create the producer options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Func<EventRegistration, EventHubProducerClientOptions> CreateProducerClientOptions { get; set; }
+        public Action<EventRegistration, EventHubProducerClientOptions> CreateProducerClientOptions { get; set; }
 
         /// <summary>
         /// A function to create the processor options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Func<EventConsumerRegistration, EventProcessorClientOptions> CreateProcessorClientOptions { get; set; }
+        public Action<EventConsumerRegistration, EventProcessorClientOptions> CreateProcessorClientOptions { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
@@ -57,12 +57,12 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A function to create the producer options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Action<EventRegistration, EventHubProducerClientOptions> CreateProducerClientOptions { get; set; }
+        public Action<EventRegistration, EventHubProducerClientOptions> SetupProducerClientOptions { get; set; }
 
         /// <summary>
         /// A function to create the processor options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Action<EventConsumerRegistration, EventProcessorClientOptions> CreateProcessorClientOptions { get; set; }
+        public Action<EventRegistration, EventConsumerRegistration, EventProcessorClientOptions> SetupProcessorClientOptions { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
@@ -3,6 +3,7 @@ using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Producer;
 using System;
 using Tingle.EventBus;
+using Tingle.EventBus.Registrations;
 using Tingle.EventBus.Transports;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -53,15 +54,15 @@ namespace Microsoft.Extensions.DependencyInjection
         public bool UseBasicTier { get; set; } = true;
 
         /// <summary>
-        /// A function to create the processor options instead of using the default options.
-        /// Some options set may still be overriding for proper operation of the the transport and the bus.
-        /// </summary>
-        public Func<EventProcessorClientOptions> CreateProcessorClientOptions { get; set; }
-
-        /// <summary>
         /// A function to create the producer options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Func<EventHubProducerClientOptions> CreateProducerClientOptions { get; set; }
+        public Func<EventRegistration, EventHubProducerClientOptions> CreateProducerClientOptions { get; set; }
+
+        /// <summary>
+        /// A function to create the processor options instead of using the default options.
+        /// Some options set may still be overriding for proper operation of the the transport and the bus.
+        /// </summary>
+        public Func<EventConsumerRegistration, EventProcessorClientOptions> CreateProcessorClientOptions { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -432,7 +432,15 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 {
                     // set the defaults for a queue here
                     Status = EntityStatus.Active,
-                    MaxDeliveryCount = 10,
+                    EnablePartitioning = false,
+                    RequiresDuplicateDetection = BusOptions.EnableDeduplication,
+                    DuplicateDetectionHistoryTimeWindow = BusOptions.DuplicateDetectionDuration,
+                    AutoDeleteOnIdle = Defaults.AutoDeleteOnIdle,
+                    DefaultMessageTimeToLive = Defaults.DefaultMessageTimeToLive,
+                    EnableBatchedOperations = true,
+                    DeadLetteringOnMessageExpiration = true,
+                    LockDuration = Defaults.LockDuration,
+                    MaxDeliveryCount = Defaults.MaxDeliveryCount,
                 };
 
                 // Allow for the defaults to be overriden
@@ -458,11 +466,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 Logger.LogTrace("Topic '{TopicName}' does not exist, preparing creation.", name);
                 var options = new CreateTopicOptions(name: name)
                 {
-                    // set the defaults for a topic here
                     Status = EntityStatus.Active,
                     EnablePartitioning = false,
                     RequiresDuplicateDetection = BusOptions.EnableDeduplication,
                     DuplicateDetectionHistoryTimeWindow = BusOptions.DuplicateDetectionDuration,
+                    AutoDeleteOnIdle = Defaults.AutoDeleteOnIdle,
+                    DefaultMessageTimeToLive = Defaults.DefaultMessageTimeToLive,
+                    EnableBatchedOperations = true,
                 };
 
                 // Allow for the defaults to be overriden
@@ -492,9 +502,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                                 topicName);
                 var options = new CreateSubscriptionOptions(topicName: topicName, subscriptionName: subscriptionName)
                 {
-                    // set the defaults for a subscription here
                     Status = EntityStatus.Active,
-                    MaxDeliveryCount = 10,
+                    AutoDeleteOnIdle = Defaults.AutoDeleteOnIdle,
+                    DefaultMessageTimeToLive = Defaults.DefaultMessageTimeToLive,
+                    EnableBatchedOperations = true,
+                    DeadLetteringOnMessageExpiration = true,
+                    LockDuration = Defaults.LockDuration,
+                    MaxDeliveryCount = Defaults.MaxDeliveryCount,
                 };
 
                 // Allow for the defaults to be overriden

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -362,7 +362,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 if (!processorsCache.TryGetValue(key, out var processor))
                 {
                     // Create the processor options
-                    var sbpo = TransportOptions.CreateProcessorOptions?.Invoke() ?? new ServiceBusProcessorOptions();
+                    var sbpo = TransportOptions.CreateProcessorOptions?.Invoke(ereg, creg) ?? new ServiceBusProcessorOptions();
 
                     // Maximum number of concurrent calls to the callback ProcessMessagesAsync(), set to 1 for simplicity.
                     // Set it according to how many messages the application wants to process in parallel.

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -372,6 +372,9 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                     // False below indicates the Complete will be handled by the User Callback as in `ProcessMessagesAsync` below.
                     sbpo.AutoCompleteMessages = false;
 
+                    // Set the period of time for which to keep renewing the lock token
+                    sbpo.MaxAutoLockRenewalDuration = Defaults.MaxAutoLockRenewDuration;
+
                     // Create the processor. Queues are used in the basic tier or when explicitly mapped to Queue.
                     // Otherwise, Topics and Subscriptions are used.
                     if (ereg.EntityKind == EntityKind.Queue)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -378,7 +378,6 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                     // Allow for the defaults to be overriden
                     TransportOptions.SetupProcessorOptions?.Invoke(ereg, creg, sbpo);
 
-
                     // Create the processor. Queues are used in the basic tier or when explicitly mapped to Queue.
                     // Otherwise, Topics and Subscriptions are used.
                     if (ereg.EntityKind == EntityKind.Queue)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -327,13 +327,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                     {
                         // Ensure Queue is created
                         Logger.LogDebug("Creating sender for queue '{QueueName}'", name);
-                        await CreateQueueIfNotExistsAsync(name: name, cancellationToken: cancellationToken);
+                        await CreateQueueIfNotExistsAsync(ereg: reg, name: name, cancellationToken: cancellationToken);
                     }
                     else
                     {
                         // Ensure topic is created
                         Logger.LogDebug("Creating sender for topic '{TopicName}'", name);
-                        await CreateTopicIfNotExistsAsync(name: name, cancellationToken: cancellationToken);
+                        await CreateTopicIfNotExistsAsync(ereg: reg, name: name, cancellationToken: cancellationToken);
                     }
 
                     // Create the sender
@@ -377,7 +377,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                     if (ereg.EntityKind == EntityKind.Queue)
                     {
                         // Ensure Queue is created
-                        await CreateQueueIfNotExistsAsync(name: topicName, cancellationToken: cancellationToken);
+                        await CreateQueueIfNotExistsAsync(ereg: ereg, name: topicName, cancellationToken: cancellationToken);
 
                         // Create the processor for the Queue
                         Logger.LogDebug("Creating processor for queue '{QueueName}'", topicName);
@@ -386,12 +386,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                     else
                     {
                         // Ensure Topic is created before creating the Subscription
-                        await CreateTopicIfNotExistsAsync(name: topicName, cancellationToken: cancellationToken);
+                        await CreateTopicIfNotExistsAsync(ereg: ereg, name: topicName, cancellationToken: cancellationToken);
 
                         // Ensure Subscription is created
-                        await CreateSubscriptionIfNotExistsAsync(topicName: topicName,
-                                                                subscriptionName: subscriptionName,
-                                                                cancellationToken: cancellationToken);
+                        await CreateSubscriptionIfNotExistsAsync(creg: creg,
+                                                                 topicName: topicName,
+                                                                 subscriptionName: subscriptionName,
+                                                                 cancellationToken: cancellationToken);
 
                         // Create the processor for the Subscription
                         Logger.LogDebug("Creating processor for topic '{TopicName}' and subscription '{Subscription}'",
@@ -413,7 +414,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
             }
         }
 
-        private async Task CreateQueueIfNotExistsAsync(string name, CancellationToken cancellationToken)
+        private async Task CreateQueueIfNotExistsAsync(EventRegistration ereg, string name, CancellationToken cancellationToken)
         {
             // if entity creation is not enabled, just return
             if (!TransportOptions.EnableEntityCreation)
@@ -435,13 +436,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 };
 
                 // Allow for the defaults to be overriden
-                TransportOptions.SetupQueueOptions?.Invoke(options);
+                TransportOptions.SetupQueueOptions?.Invoke(ereg, options);
                 Logger.LogInformation("Creating queue '{QueueName}'", name);
                 _ = await managementClient.CreateQueueAsync(options: options, cancellationToken: cancellationToken);
             }
         }
 
-        private async Task CreateTopicIfNotExistsAsync(string name, CancellationToken cancellationToken)
+        private async Task CreateTopicIfNotExistsAsync(EventRegistration ereg, string name, CancellationToken cancellationToken)
         {
             // if entity creation is not enabled, just return
             if (!TransportOptions.EnableEntityCreation)
@@ -465,13 +466,13 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 };
 
                 // Allow for the defaults to be overriden
-                TransportOptions.SetupTopicOptions?.Invoke(options);
+                TransportOptions.SetupTopicOptions?.Invoke(ereg, options);
                 Logger.LogInformation("Creating topic '{TopicName}'", name);
                 _ = await managementClient.CreateTopicAsync(options: options, cancellationToken: cancellationToken);
             }
         }
 
-        private async Task CreateSubscriptionIfNotExistsAsync(string topicName, string subscriptionName, CancellationToken cancellationToken)
+        private async Task CreateSubscriptionIfNotExistsAsync(EventConsumerRegistration creg, string topicName, string subscriptionName, CancellationToken cancellationToken)
         {
             // if entity creation is not enabled, just return
             if (!TransportOptions.EnableEntityCreation)
@@ -497,7 +498,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                 };
 
                 // Allow for the defaults to be overriden
-                TransportOptions.SetupSubscriptionOptions?.Invoke(options);
+                TransportOptions.SetupSubscriptionOptions?.Invoke(creg, options);
                 Logger.LogInformation("Creating subscription '{SubscriptionName}' under topic '{TopicName}'",
                                       subscriptionName,
                                       topicName);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
@@ -48,6 +48,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A function to create the processor options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Func<ServiceBusProcessorOptions> CreateProcessorOptions { get; set; }
+        public Func<EventRegistration, EventConsumerRegistration, ServiceBusProcessorOptions> CreateProcessorOptions { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
@@ -48,6 +48,6 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A function to create the processor options instead of using the default options.
         /// Some options set may still be overriding for proper operation of the the transport and the bus.
         /// </summary>
-        public Func<EventRegistration, EventConsumerRegistration, ServiceBusProcessorOptions> CreateProcessorOptions { get; set; }
+        public Action<EventRegistration, EventConsumerRegistration, ServiceBusProcessorOptions> SetupProcessorOptions { get; set; }
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransportOptions.cs
@@ -2,6 +2,7 @@
 using Azure.Messaging.ServiceBus.Administration;
 using System;
 using Tingle.EventBus;
+using Tingle.EventBus.Registrations;
 using Tingle.EventBus.Transports;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -29,19 +30,19 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A setup function for setting up options for a queue.
         /// This is only called before creation.
         /// </summary>
-        public Action<CreateQueueOptions> SetupQueueOptions { get; set; }
+        public Action<EventRegistration, CreateQueueOptions> SetupQueueOptions { get; set; }
 
         /// <summary>
         /// A setup function for setting up options for a topic.
         /// This is only called before creation.
         /// </summary>
-        public Action<CreateTopicOptions> SetupTopicOptions { get; set; }
+        public Action<EventRegistration, CreateTopicOptions> SetupTopicOptions { get; set; }
 
         /// <summary>
         /// A setup function for setting up options for a subscription.
         /// This is only called before creation.
         /// </summary>
-        public Action<CreateSubscriptionOptions> SetupSubscriptionOptions { get; set; }
+        public Action<EventConsumerRegistration, CreateSubscriptionOptions> SetupSubscriptionOptions { get; set; }
 
         /// <summary>
         /// A function to create the processor options instead of using the default options.

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/Defaults.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/Defaults.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Tingle.EventBus.Transports.Azure.ServiceBus
+{
+    /// <summary>
+    /// Defaults for Azure Service Bus based transport.
+    /// </summary>
+    public static class Defaults
+    {
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        public static TimeSpan LockDuration = TimeSpan.FromMinutes(5);
+        public static TimeSpan DefaultMessageTimeToLive = TimeSpan.FromDays(365 + 1);
+        public static TimeSpan BasicMessageTimeToLive = TimeSpan.FromDays(14);
+        public static int MaxDeliveryCount = 5;
+
+        public static TimeSpan AutoDeleteOnIdle => TimeSpan.FromDays(427);
+#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
+    }
+}

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/Defaults.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/Defaults.cs
@@ -14,6 +14,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
         public static int MaxDeliveryCount = 5;
 
         public static TimeSpan AutoDeleteOnIdle => TimeSpan.FromDays(427);
+        public static TimeSpan MaxAutoLockRenewDuration => TimeSpan.FromMinutes(5);
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
     }
 }

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransportOptions.cs
@@ -3,6 +3,7 @@ using Confluent.Kafka.Admin;
 using System;
 using System.Collections.Generic;
 using Tingle.EventBus;
+using Tingle.EventBus.Registrations;
 using Tingle.EventBus.Transports;
 
 namespace Microsoft.Extensions.DependencyInjection
@@ -10,7 +11,7 @@ namespace Microsoft.Extensions.DependencyInjection
     /// <summary>
     /// Options for configuring Kafka based event bus.
     /// </summary>
-    public class KafkaTransportOptions: EventBusTransportOptionsBase
+    public class KafkaTransportOptions : EventBusTransportOptionsBase
     {
         /// <inheritdoc/>
         public override EntityKind DefaultEntityKind { get; set; } = EntityKind.Broadcast;
@@ -29,7 +30,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// A setup function for setting up specifications for a topic.
         /// This is only called before creation.
         /// </summary>
-        public Action<TopicSpecification> SetupTopicSpecification { get; set; }
+        public Action<EventRegistration, TopicSpecification> SetupTopicSpecification { get; set; }
 
         /// <summary>
         /// The number of events consumed after which to checkpoint.


### PR DESCRIPTION
In this PR:

1. `EventRegistration` and `EventConsumerRegistration` are passed in actions/delegates used to setting up options for entities before creation.
2. Better defaults are introduced for Azure Service Bus hence better performance
3. Support for auto-complete in Azure Service Bus
