### PR TITLE
Unhandled consumer error behaviour

### DIFF
--- a/Tingle.EventBus.sln
+++ b/Tingle.EventBus.sln
@@ -52,7 +52,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Tests", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Tests.InMemoryHarness", "tests\Tingle.EventBus.Tests.InMemoryHarness\Tingle.EventBus.Tests.InMemoryHarness.csproj", "{6536B1EC-D297-473F-9C18-DD42304CB9FE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tingle.EventBus.Transports.Azure.ServiceBus.Tests", "tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests.csproj", "{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Transports.Azure.EventHubs.Tests", "tests\Tingle.EventBus.Transports.Azure.EventHubs.Tests\Tingle.EventBus.Transports.Azure.EventHubs.Tests.csproj", "{B52EE5B6-D86E-4415-8688-E835220AD219}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Transports.Azure.ServiceBus.Tests", "tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests.csproj", "{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -128,6 +130,10 @@ Global
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B52EE5B6-D86E-4415-8688-E835220AD219}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B52EE5B6-D86E-4415-8688-E835220AD219}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B52EE5B6-D86E-4415-8688-E835220AD219}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B52EE5B6-D86E-4415-8688-E835220AD219}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -154,6 +160,7 @@ Global
 		{2FEC41FE-188B-4B02-943B-0FEAB0E1FA39} = {62F603F3-FF36-4E36-AC0C-08D1883525BE}
 		{108968DB-1C48-4B53-9F23-CE7C5BAA88B4} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
+		{B52EE5B6-D86E-4415-8688-E835220AD219} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
 		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution

--- a/Tingle.EventBus.sln
+++ b/Tingle.EventBus.sln
@@ -52,6 +52,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Tests", "te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tingle.EventBus.Tests.InMemoryHarness", "tests\Tingle.EventBus.Tests.InMemoryHarness\Tingle.EventBus.Tests.InMemoryHarness.csproj", "{6536B1EC-D297-473F-9C18-DD42304CB9FE}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tingle.EventBus.Transports.Azure.ServiceBus.Tests", "tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests\Tingle.EventBus.Transports.Azure.ServiceBus.Tests.csproj", "{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +128,10 @@ Global
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,6 +154,7 @@ Global
 		{2FEC41FE-188B-4B02-943B-0FEAB0E1FA39} = {62F603F3-FF36-4E36-AC0C-08D1883525BE}
 		{108968DB-1C48-4B53-9F23-CE7C5BAA88B4} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
 		{6536B1EC-D297-473F-9C18-DD42304CB9FE} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
+		{C2E8CDC9-E607-4DDF-9796-98EF9CAFC65D} = {BDD324B6-9EFC-49A3-9CF6-6CE494446C4B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9E5CC03E-DDE6-4455-9D5D-03617DE5DBD8}

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/Tingle.EventBus.Transports.Azure.EventHubs.csproj
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/Tingle.EventBus.Transports.Azure.EventHubs.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Tingle.EventBus.Transports.Azure.EventHubs.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.4.0" />
   </ItemGroup>
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -634,7 +634,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
 
         private bool IsBasicTier => namespaceProperties.MessagingSku == MessagingSku.Basic;
 
-        internal static PostConsumeAction? DecideAction(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool autoComplete) // TODO: unit test this
+        internal static PostConsumeAction? DecideAction(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool autoComplete)
         {
             /*
              * Possible actions

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -593,6 +593,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
             Logger.LogDebug("Post Consume action: {Action} for message: {MessageId} from '{EntityPath}' containing Event: {EventId}.",
                             action,
                             messageId,
+                            entityPath,
                             context.Id);
 
             if (action == PostConsumeAction.Complete)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/Tingle.EventBus.Transports.Azure.ServiceBus.csproj
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/Tingle.EventBus.Transports.Azure.ServiceBus.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="Tingle.EventBus.Transports.Azure.ServiceBus.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.1.2" />
   </ItemGroup>
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Extensions.DependencyInjection
         public AsyncRetryPolicy DefaultConsumerRetryPolicy { get; set; }
 
         /// <summary>
+        /// Optional default behaviour for errors encountered in a consumer but are not handled.
+        /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.UnhandledErrorBehaviour"/> option.
+        /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultUnhandledConsumerErrorBehaviour"/> option on the specific transport.
+        /// When an <see cref="AsyncRetryPolicy"/> is in force, only errors that are not handled by it will be subject to the value set here.
+        /// Defaults to <see langword="null"/>.
+        /// </summary>
+        public UnhandledConsumerErrorBehaviour? DefaultUnhandledConsumerErrorBehaviour { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the default transport.
         /// When there is only one transport registered, setting this value is not necessary, as it is used as the default.
         /// </summary>

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Extensions.Logging
         {
             Action<ILogger, string, Exception> action = behaviour switch
             {
-                UnhandledConsumerErrorBehaviour.DeadletterImmediately => _consumeFailedDeadletter,
+                UnhandledConsumerErrorBehaviour.Deadletter => _consumeFailedDeadletter,
                 UnhandledConsumerErrorBehaviour.Discard => _consumeFailedDiscard,
                 _ => _consumeFailedTransportHandling,
             };

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -102,6 +102,24 @@ namespace Microsoft.Extensions.Logging
                 logLevel: LogLevel.Information,
                 formatString: "Canceling {EventsCount} events on '{TransportName}' transport.\r\nEvents: {EventIds}");
 
+        private static readonly Action<ILogger, string, Exception> _consumeFailedTransportHandling
+            = LoggerMessage.Define<string>(
+                eventId: new EventId(304, nameof(ConsumeFailed)),
+                logLevel: LogLevel.Error,
+                formatString: "Event processing failed. Transport specific handling in play. (EventId:{EventId})");
+
+        private static readonly Action<ILogger, string, Exception> _consumeFailedDeadletter
+            = LoggerMessage.Define<string>(
+                eventId: new EventId(304, nameof(ConsumeFailed)),
+                logLevel: LogLevel.Error,
+                formatString: "Event processing failed. Moving to deadletter. (EventId:{EventId})");
+
+        private static readonly Action<ILogger, string, Exception> _consumeFailedDiscard
+            = LoggerMessage.Define<string>(
+                eventId: new EventId(304, nameof(ConsumeFailed)),
+                logLevel: LogLevel.Error,
+                formatString: "Event processing failed. Discarding event. (EventId:{EventId})");
+
         public static void SendingEvent(this ILogger logger, string eventId, string transportName, DateTimeOffset? scheduled = null)
         {
             if (scheduled == null)
@@ -151,6 +169,18 @@ namespace Microsoft.Extensions.Logging
         public static void CancelingEvents(this ILogger logger, IList<string> eventIds, string transportName)
         {
             _cancelingEvents(logger, eventIds.Count, transportName, eventIds, null);
+        }
+
+        public static void ConsumeFailed(this ILogger logger, string eventId, UnhandledConsumerErrorBehaviour? behaviour, Exception ex)
+        {
+            Action<ILogger, string, Exception> action = behaviour switch
+            {
+                UnhandledConsumerErrorBehaviour.DeadletterImmediately => _consumeFailedDeadletter,
+                UnhandledConsumerErrorBehaviour.Discard => _consumeFailedDiscard,
+                _ => _consumeFailedTransportHandling,
+            };
+
+            action?.Invoke(logger, eventId, ex);
         }
 
         private static (string readableDelay, TimeSpan delay) GetDelay(DateTimeOffset scheduled)

--- a/src/Tingle.EventBus/Registrations/EventConsumerRegistration.cs
+++ b/src/Tingle.EventBus/Registrations/EventConsumerRegistration.cs
@@ -30,7 +30,8 @@ namespace Tingle.EventBus.Registrations
 
         /// <summary>
         /// The retry policy to apply when consuming events.
-        /// This is an outter wrapper around the <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, System.Threading.CancellationToken)"/>
+        /// This is an outter wrapper around the
+        /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, System.Threading.CancellationToken)"/>
         /// method.
         /// When set to <see langword="null"/>, the method is only invoked once.
         /// Defaults to <see langword="null"/>.
@@ -43,6 +44,20 @@ namespace Tingle.EventBus.Registrations
         /// or lock duration) is set to accommodate the longest possible duration of the retry policy.
         /// </remarks>
         public AsyncRetryPolicy RetryPolicy { get; set; }
+
+        /// <summary>
+        /// The behaviour for unhandled errors when consuming events via the
+        /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, System.Threading.CancellationToken)"/>
+        /// method.
+        /// When set to <see langword="null"/>, the transport's default behaviour is used.
+        /// Depending on the transport, the event may be delayed for reconsumtion
+        /// or added back to the entity or availed to another processor/consumer instnance.
+        /// Defaults to <see langword="null"/>.
+        /// When this value is set, it overrides the default value set on the transport or the bus.
+        /// <br/>
+        /// When a <see cref="RetryPolicy"/> is in force, only errors not handled by it will be subject to the value set here.
+        /// </summary>
+        public UnhandledConsumerErrorBehaviour? UnhandledErrorBehaviour { get; set; }
 
         /// <summary>
         /// Gets a key/value collection that can be used to organize and share data across components

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -126,6 +126,8 @@ namespace Tingle.EventBus.Transports
             return Task.CompletedTask;
         }
 
+        #region Serialization
+
         /// <summary>
         /// Deserialize an event from a stream of bytes.
         /// </summary>
@@ -180,6 +182,10 @@ namespace Tingle.EventBus.Transports
             await serializer.SerializeAsync(body, @event, BusOptions.HostInfo, cancellationToken);
         }
 
+        #endregion
+
+        #region Consuming
+
         /// <summary>
         /// Push an incoming event to the consumer responsible for it.
         /// </summary>
@@ -188,8 +194,8 @@ namespace Tingle.EventBus.Transports
         /// <param name="creg">The <see cref="EventConsumerRegistration"/> for the current event.</param>
         /// <param name="event">The context containing the event.</param>
         /// <param name="scope">The scope in which to resolve required services.</param>
-        /// <returns></returns>
         /// <param name="cancellationToken"></param>
+        /// <returns></returns>
         protected async Task ConsumeAsync<TEvent, TConsumer>(EventConsumerRegistration creg,
                                                              EventContext<TEvent> @event,
                                                              IServiceScope scope,
@@ -210,6 +216,8 @@ namespace Tingle.EventBus.Transports
                 await consumer.ConsumeAsync(@event, cancellationToken).ConfigureAwait(false);
             }
         }
+
+        #endregion
 
         /// <summary>
         /// Create an <see cref="IServiceScope"/> which contains an <see cref="IServiceProvider"/>
@@ -233,6 +241,7 @@ namespace Tingle.EventBus.Transports
         #endregion
 
         #region Logging
+
         /// <summary>
         /// Begins a logical operation scope for logging.
         /// </summary>

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
@@ -51,6 +51,15 @@ namespace Tingle.EventBus.Transports
         public AsyncRetryPolicy DefaultConsumerRetryPolicy { get; set; }
 
         /// <summary>
+        /// Optional default behaviour for errors encountered in a consumer but are not handled.
+        /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultUnhandledConsumerErrorBehaviour"/>.
+        /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.UnhandledErrorBehaviour"/> option.
+        /// When an <see cref="AsyncRetryPolicy"/> is in force, only errors that are not handled by it will be subject to the value set here.
+        /// Defaults to <see langword="null"/>.
+        /// </summary>
+        public UnhandledConsumerErrorBehaviour? DefaultUnhandledConsumerErrorBehaviour { get; set; }
+
+        /// <summary>
         /// Ensures the value set for <see cref="EventRegistration.EntityKind"/> is among the allowed values.
         /// If no value is set, the default value (set via <see cref="DefaultEntityKind"/>) is set before checking.
         /// </summary>

--- a/src/Tingle.EventBus/Transports/EventConsumeResult.cs
+++ b/src/Tingle.EventBus/Transports/EventConsumeResult.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace Tingle.EventBus.Transports
+{
+    /// <summary>
+    /// Represents the result from consuming an event.
+    /// This only used by the transport(s) and should not be used by the final application.
+    /// </summary>
+    public struct EventConsumeResult
+    {
+        /// <summary>
+        /// Create an instance of <see cref="EventConsumeResult"/>
+        /// </summary>
+        /// <param name="successful">See <see cref="Successful"/>.</param>
+        /// <param name="exception">See <see cref="Exception"/>.</param>
+        internal EventConsumeResult(bool successful, Exception exception = null)
+        {
+            Successful = successful;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// Indicates if the consuming action was successful.
+        /// </summary>
+        public bool Successful { get; }
+
+        /// <summary>
+        /// Exception caught for failures.
+        /// </summary>
+        public Exception Exception { get; }
+
+        /// <summary>
+        /// Deconstruct the result into parts
+        /// </summary>
+        /// <param name="successful">See <see cref="Successful"/>.</param>
+        /// <param name="exception">See <see cref="Exception"/>.</param>
+        public void Deconstruct(out bool successful, out Exception exception)
+        {
+            successful = Successful;
+            exception = Exception;
+        }
+    }
+}

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
@@ -368,7 +368,7 @@ namespace Tingle.EventBus.Transports.InMemory
                 failed.Add(context);
 
                 // Deadletter if needed
-                if (creg.UnhandledErrorBehaviour == UnhandledConsumerErrorBehaviour.DeadletterImmediately)
+                if (creg.UnhandledErrorBehaviour == UnhandledConsumerErrorBehaviour.Deadletter)
                 {
                     // get the dead letter queue and send the mesage there
                     var dlqEntity = await GetQueueAsync(reg: reg, deadletter: true, cancellationToken: cancellationToken);

--- a/src/Tingle.EventBus/UnhandledConsumerErrorBehaviour.cs
+++ b/src/Tingle.EventBus/UnhandledConsumerErrorBehaviour.cs
@@ -11,7 +11,7 @@
         /// Move the event to dead-letter entity.
         /// Handling of deadletter is transport specific.
         /// </summary>
-        DeadletterImmediately,
+        Deadletter,
 
         /// <summary>
         /// Discard the event.

--- a/src/Tingle.EventBus/UnhandledConsumerErrorBehaviour.cs
+++ b/src/Tingle.EventBus/UnhandledConsumerErrorBehaviour.cs
@@ -1,0 +1,22 @@
+﻿namespace Tingle.EventBus
+{
+    /// <summary>
+    /// The behaviour to follow when an unhandled error in a consumer's
+    /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, System.Threading.CancellationToken)"/>
+    /// invocation results in an excetion that is not handled.
+    /// </summary>
+    public enum UnhandledConsumerErrorBehaviour
+    {
+        /// <summary>
+        /// Move the event to dead-letter entity.
+        /// Handling of deadletter is transport specific.
+        /// </summary>
+        DeadletterImmediately,
+
+        /// <summary>
+        /// Discard the event.
+        /// Depending on the transport, the event can be ignored, abandoned or skipped.
+        /// </summary>
+        Discard,
+    }
+}

--- a/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/AzureEventHubsTransportTests.cs
+++ b/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/AzureEventHubsTransportTests.cs
@@ -1,0 +1,20 @@
+using Xunit;
+
+namespace Tingle.EventBus.Transports.Azure.EventHubs.Tests
+{
+    public class AzureEventHubsTransportTests
+    {
+        [Theory]
+        [InlineData(true, null, true)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Deadletter, true)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Discard, true)]
+        [InlineData(false, null, false)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Deadletter, true)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Discard, true)]
+        public void ShouldCheckpoint_Works(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool expected)
+        {
+            var actual = AzureEventHubsTransport.ShouldCheckpoint(successful, behaviour);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests.csproj
+++ b/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tingle.EventBus.Transports.Azure.EventHubs\Tingle.EventBus.Transports.Azure.EventHubs.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests/AzureServiceBusTransportTests.cs
+++ b/tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests/AzureServiceBusTransportTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+
+namespace Tingle.EventBus.Transports.Azure.ServiceBus.Tests
+{
+    public class AzureServiceBusTransportTests
+    {
+        [Theory]
+        [InlineData(false, null, false, PostConsumeAction.Abandon)]
+        [InlineData(false, null, true, PostConsumeAction.Throw)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Deadletter, false, PostConsumeAction.Deadletter)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Deadletter, true, PostConsumeAction.Throw)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Discard, false, PostConsumeAction.Complete)]
+        [InlineData(false, UnhandledConsumerErrorBehaviour.Discard, true, null)]
+        [InlineData(true, null, false, PostConsumeAction.Complete)]
+        [InlineData(true, null, true, null)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Deadletter, false, PostConsumeAction.Complete)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Deadletter, true, null)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Discard, false, PostConsumeAction.Complete)]
+        [InlineData(true, UnhandledConsumerErrorBehaviour.Discard, true, null)]
+        internal void DecideAction_Works(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool autoComplete, PostConsumeAction? expected)
+        {
+            var actual = AzureServiceBusTransport.DecideAction(successful: successful,
+                                                               behaviour: behaviour,
+                                                               autoComplete: autoComplete);
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests.csproj
+++ b/tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests/Tingle.EventBus.Transports.Azure.ServiceBus.Tests.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Tingle.EventBus.Transports.Azure.ServiceBus\Tingle.EventBus.Transports.Azure.ServiceBus.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Introduced configurable behaviour for when consumers fail (i.e. the `ConsumeAsync<TEvent>(...)` method).
This PR allows the transport to handle the error in a default fashion or for the developer to set `Deadletter` or `Discard` options. The control is done at the consumer registration level but defaults can be set on the transport and/or bus.