### PR TITLE
Configurable Event Id format

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisPostConfigureOptions.cs
@@ -35,6 +35,9 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.AmazonKinesis);
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast);
 

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsPostConfigureOptions.cs
@@ -32,6 +32,9 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.AmazonSqs);
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast, EntityKind.Queue);
 

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
@@ -49,6 +49,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast);
 

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStoragePostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStoragePostConfigureOptions.cs
@@ -38,6 +38,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata#queue-names
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Queue);
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusPostConfigureOptions.cs
@@ -29,6 +29,9 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.AzureServiceBus);
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast, EntityKind.Queue);
 

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaPostConfigureOptions.cs
@@ -57,6 +57,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast);
 

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqPostConfigureOptions.cs
@@ -68,6 +68,9 @@ namespace Microsoft.Extensions.DependencyInjection
             // See https://www.rabbitmq.com/queues.html#:~:text=Names,bytes%20of%20UTF%2D8%20characters.
             foreach (var ereg in registrations)
             {
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
+
                 // Ensure the entity type is allowed
                 options.EnsureAllowedEntityKind(ereg, EntityKind.Broadcast, EntityKind.Queue);
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -71,6 +71,14 @@ namespace Microsoft.Extensions.DependencyInjection
         public TimeSpan DuplicateDetectionDuration { get; set; } = TimeSpan.FromMinutes(1);
 
         /// <summary>
+        /// Optional default format to use for generated event identifiers when for events where it is not specified.
+        /// To specify a value per consumer, use the <see cref="EventRegistration.IdFormat"/> option.
+        /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultEventIdFormat"/> option on the specific transport.
+        /// Defaults to <see cref="EventIdFormat.Guid"/>.
+        /// </summary>
+        public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
+
+        /// <summary>
         /// Optional default retry policy to use for consumers where it is not specified.
         /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.
         /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultConsumerRetryPolicy"/> option on the specific transport.

--- a/src/Tingle.EventBus/DependencyInjection/TransportOptionsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/TransportOptionsPostConfigureOptions.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Extensions.DependencyInjection
     /// for shared settings in <see cref="EventBusTransportOptionsBase"/>.
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    internal class TransportOptionsPostConfigureOptions<T> : IPostConfigureOptions<EventBusTransportOptionsBase>
+    internal class TransportOptionsPostConfigureOptions<T> : IPostConfigureOptions<T> where T : EventBusTransportOptionsBase
     {
-        public void PostConfigure(string name, EventBusTransportOptionsBase options)
+        public void PostConfigure(string name, T options)
         {
             // check bounds for empty results delay
             var ticks = options.EmptyResultsDelay.Ticks;

--- a/src/Tingle.EventBus/EventIdFormat.cs
+++ b/src/Tingle.EventBus/EventIdFormat.cs
@@ -1,0 +1,50 @@
+﻿namespace Tingle.EventBus
+{
+    /// <summary>
+    /// The preferred format to use for values generated for<see cref="EventContext.Id"/>.
+    /// </summary>
+    public enum EventIdFormat
+    {
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/>.
+        /// For example <c>17a2a99b-9b40-4f93-9333-7036154d20a8</c>
+        /// </summary>
+        Guid,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> but the dashes are removed.
+        /// For example <c>17a2a99b9b404f9393337036154d20a8</c>
+        /// </summary>
+        GuidNoDashes,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> but only the first 8 bytes are changed to <see cref="ulong"/>.
+        /// For example <c>5734097450149521819</c>
+        /// </summary>
+        Long,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> but only the first 8 bytes are changed to <see cref="ulong"/>.
+        /// For example <c>4f939b4017a2a99b</c>
+        /// </summary>
+        LongHex,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> and converted to two <see cref="ulong"/> concantenated.
+        /// For example <c>573409745014952181912114767751129609107</c>
+        /// </summary>
+        DoubleLong,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> and converted to two <see cref="ulong"/> concantenated.
+        /// For example <c>4f939b4017a2a99ba8204d1536703393</c>
+        /// </summary>
+        DoubleLongHex,
+
+        /// <summary>
+        /// Value is generated via <see cref="System.Guid.NewGuid"/> and the bytes converted to base 64.
+        /// For example <c>m6miF0Cbk0+TM3A2FU0gqA==</c>
+        /// </summary>
+        Random,
+    }
+}

--- a/src/Tingle.EventBus/Registrations/EventRegistration.cs
+++ b/src/Tingle.EventBus/Registrations/EventRegistration.cs
@@ -38,6 +38,11 @@ namespace Tingle.EventBus.Registrations
         public EntityKind? EntityKind { get; set; }
 
         /// <summary>
+        /// THe preferred format to use when generating identifiers for the event.
+        /// </summary>
+        public EventIdFormat? IdFormat { get; set; }
+
+        /// <summary>
         /// The name of the transport used for the event.
         /// </summary>
         public string TransportName { get; set; }

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -15,10 +15,10 @@ using Tingle.EventBus.Serialization;
 namespace Tingle.EventBus.Transports
 {
     /// <summary>
-    /// The abstractions for an event bus
+    /// Abstract implementation for an event bus transport.
     /// </summary>
     /// <typeparam name="TTransportOptions">The type used for configuring options of the transport</typeparam>
-    public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransport where TTransportOptions : EventBusTransportOptionsBase, new()
+    public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransportWithOptions, IEventBusTransport where TTransportOptions : EventBusTransportOptionsBase, new()
     {
         private static readonly Regex CategoryNamePattern = new Regex(@"Transport$", RegexOptions.Compiled);
         private readonly IServiceScopeFactory serviceScopeFactory;
@@ -63,6 +63,9 @@ namespace Tingle.EventBus.Transports
 
         ///
         protected ILogger Logger { get; }
+
+        /// <inheritdoc/>
+        EventBusTransportOptionsBase IEventBusTransportWithOptions.GetOptions() => TransportOptions;
 
         /// <inheritdoc/>
         public abstract Task<bool> CheckHealthAsync(Dictionary<string, object> data,

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
@@ -87,5 +87,17 @@ namespace Tingle.EventBus.Transports
                 throw new InvalidOperationException($"'{nameof(EntityKind)}.{ek}' is not permitted for '{ereg.TransportName}' transport.");
             }
         }
+
+        /// <summary>
+        /// Set value for <see cref="EventRegistration.IdFormat"/> with prioritization of the transport default over the bus default.
+        /// </summary>
+        /// <param name="ereg"></param>
+        /// <param name="busOptions"></param>
+        public void SetEventIdFormat(EventRegistration ereg, EventBusOptions busOptions)
+        {
+            // prioritize the transport
+            ereg.IdFormat ??= DefaultEventIdFormat;
+            ereg.IdFormat ??= busOptions.DefaultEventIdFormat;
+        }
     }
 }

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
@@ -44,6 +44,13 @@ namespace Tingle.EventBus.Transports
         public virtual EntityKind DefaultEntityKind { get; set; } = EntityKind.Queue;
 
         /// <summary>
+        /// Optional default format to use for generated event identifiers when for events where it is not specified.
+        /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultEventIdFormat"/>.
+        /// To specify a value per consumer, use the <see cref="EventRegistration.IdFormat"/> option.
+        /// </summary>
+        public EventIdFormat? DefaultEventIdFormat { get; set; }
+
+        /// <summary>
         /// Optional default retry policy to use for consumers where it is not specified.
         /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultConsumerRetryPolicy"/>.
         /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.

--- a/src/Tingle.EventBus/Transports/IEventBusTransportWithOptions.cs
+++ b/src/Tingle.EventBus/Transports/IEventBusTransportWithOptions.cs
@@ -1,0 +1,7 @@
+﻿namespace Tingle.EventBus.Transports
+{
+    internal interface IEventBusTransportWithOptions
+    {
+        EventBusTransportOptionsBase GetOptions();
+    }
+}

--- a/src/Tingle.EventBus/Transports/InMemory/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/EventBusBuilderExtensions.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 services.Configure(configure);
             }
 
+            services.AddSingleton<IPostConfigureOptions<InMemoryTransportOptions>, InMemoryTransportPostConfigureOptions>();
             services.AddSingleton<SequenceNumberGenerator>();
 
             // register the transport

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransportPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransportPostConfigureOptions.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.Extensions.Options;
+using System;
+using Tingle.EventBus;
+
+namespace Microsoft.Extensions.DependencyInjection
+{
+    /// <summary>
+    /// A class to finish the configuration of instances of <see cref="InMemoryTransportOptions"/>.
+    /// </summary>
+    internal class InMemoryTransportPostConfigureOptions : IPostConfigureOptions<InMemoryTransportOptions>
+    {
+        private readonly EventBusOptions busOptions;
+
+        public InMemoryTransportPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+        {
+            busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
+        }
+
+        public void PostConfigure(string name, InMemoryTransportOptions options)
+        {
+            var registrations = busOptions.GetRegistrations(TransportNames.InMemory);
+            foreach (var ereg in registrations)
+            {
+                // Do anything necessary here
+            }
+        }
+    }
+}

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransportPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransportPostConfigureOptions.cs
@@ -21,7 +21,8 @@ namespace Microsoft.Extensions.DependencyInjection
             var registrations = busOptions.GetRegistrations(TransportNames.InMemory);
             foreach (var ereg in registrations)
             {
-                // Do anything necessary here
+                // Set the IdFormat
+                options.SetEventIdFormat(ereg, busOptions);
             }
         }
     }

--- a/tests/Tingle.EventBus.Tests/EventBusTests.cs
+++ b/tests/Tingle.EventBus.Tests/EventBusTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Tingle.EventBus.Registrations;
+using Xunit;
+
+namespace Tingle.EventBus.Tests
+{
+    public class EventBusTests
+    {
+        [Theory]
+        [InlineData(EventIdFormat.Guid)]
+        [InlineData(EventIdFormat.GuidNoDashes)]
+        [InlineData(EventIdFormat.Long)]
+        [InlineData(EventIdFormat.LongHex)]
+        [InlineData(EventIdFormat.DoubleLong)]
+        [InlineData(EventIdFormat.DoubleLongHex)]
+        [InlineData(EventIdFormat.Random)]
+        public void GenerateEventId_Works(EventIdFormat format)
+        {
+            var reg = new EventRegistration(typeof(TestEvent1)) { IdFormat = format, };
+            var id = EventBus.GenerateEventId(reg);
+            Assert.NotNull(id);
+        }
+
+        [Fact]
+        public void GenerateEventId_Throws_InvalidOperationExecption()
+        {
+            var reg = new EventRegistration(typeof(TestEvent1)) { IdFormat = null, };
+            var ex = Assert.Throws<NotSupportedException>(() => EventBus.GenerateEventId(reg));
+            Assert.Equal($"'{nameof(EventIdFormat)}.{reg.IdFormat}' set on event '{reg.EventType.FullName}' is not supported.", ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
This PR introduced support for specifying the format used for generated event IDs. Event IDs are generated only if not specified. The format can be specified per event with defaults per transport and on the bus.