### PR TITLE
Add support for XML serializer

### DIFF
--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Extensions.DependencyInjection
             Services.AddTransient<IEventPublisher, EventPublisher>();
             Services.AddSingleton<EventBus>();
             Services.AddHostedService(p => p.GetRequiredService<EventBus>());
-            UseDefaultSerializer<DefaultEventSerializer>();
+            UseDefaultSerializer<DefaultJsonEventSerializer>();
             UseDefaultReadinessProvider<DefaultReadinessProvider>();
         }
 

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -58,7 +58,7 @@ namespace Tingle.EventBus
         /// The serializer used for the event must support the value set.
         /// When set to <see langword="null"/>, the serializer used for the event decides what
         /// content type to use depending on its implementation.
-        /// For the default implementation, see <see cref="Serialization.DefaultEventSerializer"/>.
+        /// For the default implementation, see <see cref="Serialization.DefaultJsonEventSerializer"/>.
         /// </summary>
         public ContentType? ContentType { get; set; }
 

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -18,10 +18,8 @@ namespace Tingle.EventBus.Serialization
     /// </summary>
     public abstract class AbstractEventSerializer : IEventSerializer
     {
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+        ///
         protected static readonly IList<string> JsonContentTypes = new[] { "application/json", "text/json", };
-        protected static readonly IList<string> XmlContentTypes = new[] { "application/xml", "text/xml", };
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
 
         private static readonly Regex trimPattern = new("(Serializer|EventSerializer)$", RegexOptions.Compiled);
 

--- a/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
@@ -14,7 +14,7 @@ namespace Tingle.EventBus.Serialization
     /// <summary>
     /// The default implementation of <see cref="IEventSerializer"/> for JSON using the <c>System.Text.Json</c> library.
     /// </summary>
-    internal class DefaultJsonEventSerializer : AbstractEventSerializer
+    public class DefaultJsonEventSerializer : AbstractEventSerializer
     {
         /// <summary>
         /// Creates an instance of <see cref="DefaultJsonEventSerializer"/>.

--- a/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
@@ -11,21 +11,20 @@ using System.Threading.Tasks;
 
 namespace Tingle.EventBus.Serialization
 {
-
     /// <summary>
-    /// The default implementation of <see cref="IEventSerializer"/> that uses <c>System.Text.Json</c>.
+    /// The default implementation of <see cref="IEventSerializer"/> for JSON using the <c>System.Text.Json</c> library.
     /// </summary>
-    internal class DefaultEventSerializer : AbstractEventSerializer
+    internal class DefaultJsonEventSerializer : AbstractEventSerializer
     {
         /// <summary>
-        /// Creates an instance of <see cref="DefaultEventSerializer"/>.
+        /// Creates an instance of <see cref="DefaultJsonEventSerializer"/>.
         /// </summary>
         /// <param name="serviceProvider"></param>
         /// <param name="optionsAccessor">The options for configuring the serializer.</param>
         /// <param name="loggerFactory"></param>
-        public DefaultEventSerializer(IServiceProvider serviceProvider,
-                                      IOptionsMonitor<EventBusOptions> optionsAccessor,
-                                      ILoggerFactory loggerFactory)
+        public DefaultJsonEventSerializer(IServiceProvider serviceProvider,
+                                          IOptionsMonitor<EventBusOptions> optionsAccessor,
+                                          ILoggerFactory loggerFactory)
             : base(serviceProvider, optionsAccessor, loggerFactory) { }
 
         /// <inheritdoc/>

--- a/src/Tingle.EventBus/Serialization/DefaultXmlEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/DefaultXmlEventSerializer.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Mime;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Serialization;
+
+namespace Tingle.EventBus.Serialization
+{
+    /// <summary>
+    /// The default implementation of <see cref="IEventSerializer"/> for XML.
+    /// </summary>
+    public class DefaultXmlEventSerializer : AbstractEventSerializer
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="DefaultXmlEventSerializer"/>.
+        /// </summary>
+        /// <param name="serviceProvider"></param>
+        /// <param name="optionsAccessor">The options for configuring the serializer.</param>
+        /// <param name="loggerFactory"></param>
+        public DefaultXmlEventSerializer(IServiceProvider serviceProvider,
+                                         IOptionsMonitor<EventBusOptions> optionsAccessor,
+                                         ILoggerFactory loggerFactory)
+            : base(serviceProvider, optionsAccessor, loggerFactory) { }
+
+        /// <inheritdoc/>
+        protected override IList<string> SupportedMediaTypes => new[] { "application/xml", "text/xml", };
+
+        /// <inheritdoc/>
+        protected override Task<EventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
+                                                                                 ContentType? contentType,
+                                                                                 CancellationToken cancellationToken = default)
+        {
+            var serializer = new XmlSerializer(typeof(EventEnvelope<T>));
+            var envelope = (EventEnvelope<T>?)serializer.Deserialize(stream);
+            return Task.FromResult(envelope);
+        }
+
+        /// <inheritdoc/>
+        protected override Task SerializeEnvelopeAsync<T>(Stream stream,
+                                                          EventEnvelope<T> envelope,
+                                                          CancellationToken cancellationToken = default)
+        {
+            var serializer = new XmlSerializer(typeof(EventEnvelope<T>));
+            serializer.Serialize(stream, envelope);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for serialization in XML, `DefaultEventSerializer` is also renamed to `DefaultJsonEventSerializer` and made public.