### PR TITLE
ScheduledResult as a struct

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -111,10 +111,10 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs
         }
 
         /// <inheritdoc/>
-        public override async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                 EventRegistration registration,
-                                                                 DateTimeOffset? scheduled = null,
-                                                                 CancellationToken cancellationToken = default)
+        public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                          EventRegistration registration,
+                                                                          DateTimeOffset? scheduled = null,
+                                                                          CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled message
             if (scheduled != null)
@@ -144,14 +144,14 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs
             response.EnsureSuccess();
 
             // return the sequence number
-            return scheduled != null ? response.SequenceNumber : null;
+            return scheduled != null ? new ScheduledResult(id: response.SequenceNumber, scheduled: scheduled.Value) : null;
         }
 
         /// <inheritdoc/>
-        public override async Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                        EventRegistration registration,
-                                                                        DateTimeOffset? scheduled = null,
-                                                                        CancellationToken cancellationToken = default)
+        public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                 EventRegistration registration,
+                                                                                 DateTimeOffset? scheduled = null,
+                                                                                 CancellationToken cancellationToken = default)
         {
             // log warning when doing batch
             Logger.LogWarning("Amazon SNS does not support batching. The events will be looped through one by one");
@@ -193,7 +193,7 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs
             }
 
             // return the sequence numbers
-            return scheduled != null ? sequenceNumbers : null;
+            return scheduled != null ? sequenceNumbers.Select(n => new ScheduledResult(id: n, scheduled: scheduled.Value)).ToList() : null;
         }
 
 

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -125,10 +125,10 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
         }
 
         /// <inheritdoc/>
-        public override async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                 EventRegistration registration,
-                                                                 DateTimeOffset? scheduled = null,
-                                                                 CancellationToken cancellationToken = default)
+        public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                          EventRegistration registration,
+                                                                          DateTimeOffset? scheduled = null,
+                                                                          CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled event
             if (scheduled != null)
@@ -169,14 +169,14 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
             await producer.SendAsync(new[] { data }, cancellationToken);
 
             // return the sequence number
-            return data.SequenceNumber.ToString();
+            return scheduled != null ? new ScheduledResult(id: data.SequenceNumber.ToString(), scheduled: scheduled.Value) : null;
         }
 
         /// <inheritdoc/>
-        public override async Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                        EventRegistration registration,
-                                                                        DateTimeOffset? scheduled = null,
-                                                                        CancellationToken cancellationToken = default)
+        public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                 EventRegistration registration,
+                                                                                 DateTimeOffset? scheduled = null,
+                                                                                 CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled events
             if (scheduled != null)
@@ -223,7 +223,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
             await producer.SendAsync(datas, cancellationToken);
 
             // return the sequence numbers
-            return datas.Select(m => m.SequenceNumber.ToString()).ToList();
+            return scheduled != null ? datas.Select(m => new ScheduledResult(id: m.SequenceNumber.ToString(), scheduled: scheduled.Value)).ToList() : null;
         }
 
         /// <inheritdoc/>

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -120,10 +120,10 @@ namespace Tingle.EventBus.Transports.Kafka
         }
 
         /// <inheritdoc/>
-        public async override Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                 EventRegistration registration,
-                                                                 DateTimeOffset? scheduled = null,
-                                                                 CancellationToken cancellationToken = default)
+        public async override Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                          EventRegistration registration,
+                                                                          DateTimeOffset? scheduled = null,
+                                                                          CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled message
             if (scheduled != null)
@@ -155,14 +155,14 @@ namespace Tingle.EventBus.Transports.Kafka
             // Should we check persistence status?
 
             // return the sequence number
-            return scheduled != null ? result.Offset.Value.ToString() : null;
+            return scheduled != null ? new ScheduledResult(id: result.Offset.Value.ToString(), scheduled: scheduled.Value) : null;
         }
 
         /// <inheritdoc/>
-        public async override Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                        EventRegistration registration,
-                                                                        DateTimeOffset? scheduled = null,
-                                                                        CancellationToken cancellationToken = default)
+        public async override Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                 EventRegistration registration,
+                                                                                 DateTimeOffset? scheduled = null,
+                                                                                 CancellationToken cancellationToken = default)
         {
             // log warning when doing batch
             Logger.LogWarning("Kafka does not support batching. The events will be looped through one by one");
@@ -206,7 +206,7 @@ namespace Tingle.EventBus.Transports.Kafka
             }
 
             // return the sequence numbers
-            return scheduled != null ? sequenceNumbers : null;
+            return scheduled != null ? sequenceNumbers.Select(n => new ScheduledResult(id: n, scheduled: scheduled.Value)).ToList() : null;
         }
 
         /// <inheritdoc/>

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -106,10 +106,10 @@ namespace Tingle.EventBus.Transports.RabbitMQ
         }
 
         /// <inheritdoc/>
-        public override async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                 EventRegistration registration,
-                                                                 DateTimeOffset? scheduled = null,
-                                                                 CancellationToken cancellationToken = default)
+        public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                          EventRegistration registration,
+                                                                          DateTimeOffset? scheduled = null,
+                                                                          CancellationToken cancellationToken = default)
         {
             if (!IsConnected)
             {
@@ -175,14 +175,14 @@ namespace Tingle.EventBus.Transports.RabbitMQ
                                      body: ms.ToArray());
             });
 
-            return scheduledId;
+            return scheduledId != null && scheduled != null ? new ScheduledResult(id: scheduledId, scheduled: scheduled.Value) : null;
         }
 
         /// <inheritdoc/>
-        public override async Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                        EventRegistration registration,
-                                                                        DateTimeOffset? scheduled = null,
-                                                                        CancellationToken cancellationToken = default)
+        public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                 EventRegistration registration,
+                                                                                 DateTimeOffset? scheduled = null,
+                                                                                 CancellationToken cancellationToken = default)
         {
             if (!IsConnected)
             {
@@ -255,8 +255,8 @@ namespace Tingle.EventBus.Transports.RabbitMQ
                 batch.Publish();
             });
 
-            var messageIds = events.Select(m => m.Id);
-            return scheduled != null ? messageIds.ToList()! : Array.Empty<string>();
+            var messageIds = events.Select(m => m.Id!);
+            return scheduled != null ? messageIds.Select(n => new ScheduledResult(id: n, scheduled: scheduled.Value)).ToList() : Array.Empty<ScheduledResult>();
         }
 
         /// <inheritdoc/>

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -94,9 +94,9 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                        DateTimeOffset? scheduled = null,
-                                                        CancellationToken cancellationToken = default)
+        public async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                 DateTimeOffset? scheduled = null,
+                                                                 CancellationToken cancellationToken = default)
             where TEvent : class
         {
             if (scheduled != null && scheduled <= DateTimeOffset.UtcNow)
@@ -144,9 +144,9 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public async Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                               DateTimeOffset? scheduled = null,
-                                                               CancellationToken cancellationToken = default)
+        public async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                        DateTimeOffset? scheduled = null,
+                                                                        CancellationToken cancellationToken = default)
             where TEvent : class
         {
             if (scheduled != null && scheduled <= DateTimeOffset.UtcNow)
@@ -191,7 +191,7 @@ namespace Tingle.EventBus
         /// Cancel a scheduled event.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="id">The identifier of the scheduled event.</param>
+        /// <param name="id">The scheduling identifier of the scheduled event.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public async Task CancelAsync<TEvent>(string id, CancellationToken cancellationToken = default)
@@ -216,7 +216,7 @@ namespace Tingle.EventBus
         /// Cancel a batch of scheduled events.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="ids">The identifiers of the scheduled events.</param>
+        /// <param name="ids">The scheduling identifiers of the scheduled events.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         public async Task CancelAsync<TEvent>(IList<string> ids, CancellationToken cancellationToken = default)

--- a/src/Tingle.EventBus/Publisher/EventPublisher.cs
+++ b/src/Tingle.EventBus/Publisher/EventPublisher.cs
@@ -22,26 +22,26 @@ namespace Tingle.EventBus
         }
 
         /// <inheritdoc/>
-        public async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                        DateTimeOffset? scheduled = null,
-                                                        CancellationToken cancellationToken = default)
+        public async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                 DateTimeOffset? scheduled = null,
+                                                                 CancellationToken cancellationToken = default)
             where TEvent : class
         {
             return await bus.PublishAsync(@event, scheduled, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                               DateTimeOffset? scheduled = null,
-                                                               CancellationToken cancellationToken = default) where TEvent : class
+        public async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                        DateTimeOffset? scheduled = null,
+                                                                        CancellationToken cancellationToken = default) where TEvent : class
         {
             return await bus.PublishAsync(events: events, scheduled: scheduled, cancellationToken: cancellationToken);
         }
 
         /// <inheritdoc/>
-        public async Task<string?> PublishAsync<TEvent>(TEvent @event,
-                                                        DateTimeOffset? scheduled = null,
-                                                        CancellationToken cancellationToken = default)
+        public async Task<ScheduledResult?> PublishAsync<TEvent>(TEvent @event,
+                                                                 DateTimeOffset? scheduled = null,
+                                                                 CancellationToken cancellationToken = default)
             where TEvent : class
         {
             var context = CreateEventContext(@event);
@@ -49,7 +49,7 @@ namespace Tingle.EventBus
         }
 
         /// <inheritdoc/>
-        public async Task<IList<string>?> PublishAsync<TEvent>(IList<TEvent> events,
+        public async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<TEvent> events,
                                                                DateTimeOffset? scheduled = null,
                                                                CancellationToken cancellationToken = default) where TEvent : class
         {

--- a/src/Tingle.EventBus/Publisher/IEventPublisher.cs
+++ b/src/Tingle.EventBus/Publisher/IEventPublisher.cs
@@ -30,9 +30,9 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                           DateTimeOffset? scheduled = null,
-                                           CancellationToken cancellationToken = default)
+        Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                    DateTimeOffset? scheduled = null,
+                                                    CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
@@ -46,9 +46,9 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                  DateTimeOffset? scheduled = null,
-                                                  CancellationToken cancellationToken = default)
+        Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                           DateTimeOffset? scheduled = null,
+                                                           CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
@@ -62,9 +62,9 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<string?> PublishAsync<TEvent>(TEvent @event,
-                                           DateTimeOffset? scheduled = null,
-                                           CancellationToken cancellationToken = default)
+        Task<ScheduledResult?> PublishAsync<TEvent>(TEvent @event,
+                                                    DateTimeOffset? scheduled = null,
+                                                    CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
@@ -78,16 +78,16 @@ namespace Tingle.EventBus
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IList<string>?> PublishAsync<TEvent>(IList<TEvent> events,
-                                                  DateTimeOffset? scheduled = null,
-                                                  CancellationToken cancellationToken = default)
+        Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<TEvent> events,
+                                                           DateTimeOffset? scheduled = null,
+                                                           CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
         /// Cancel a scheduled event.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="id">The identifier of the scheduled event.</param>
+        /// <param name="id">The scheduling identifier of the scheduled event.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task CancelAsync<TEvent>(string id, CancellationToken cancellationToken = default)
@@ -97,7 +97,7 @@ namespace Tingle.EventBus
         /// Cancel a batch of scheduled events.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="ids">The identifiers of the scheduled events.</param>
+        /// <param name="ids">The scheduling identifiers of the scheduled events.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task CancelAsync<TEvent>(IList<string> ids, CancellationToken cancellationToken = default)

--- a/src/Tingle.EventBus/Publisher/IEventPublisherExtensions.cs
+++ b/src/Tingle.EventBus/Publisher/IEventPublisherExtensions.cs
@@ -19,10 +19,10 @@ namespace Tingle.EventBus
         /// <param name="delay">The duration of time to wait before the event is available on the bus for consumption.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static Task<string?> PublishAsync<TEvent>(this IEventPublisher publisher,
-                                                         EventContext<TEvent> @event,
-                                                         TimeSpan delay,
-                                                         CancellationToken cancellationToken = default)
+        public static Task<ScheduledResult?> PublishAsync<TEvent>(this IEventPublisher publisher,
+                                                                  EventContext<TEvent> @event,
+                                                                  TimeSpan delay,
+                                                                  CancellationToken cancellationToken = default)
             where TEvent : class
         {
             var scheduled = DateTimeOffset.UtcNow + delay;
@@ -38,10 +38,10 @@ namespace Tingle.EventBus
         /// <param name="delay">The duration of time to wait before the event is available on the bus for consumption.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static Task<IList<string>?> PublishAsync<TEvent>(this IEventPublisher publisher,
-                                                                IList<EventContext<TEvent>> events,
-                                                                TimeSpan delay,
-                                                                CancellationToken cancellationToken = default)
+        public static Task<IList<ScheduledResult>?> PublishAsync<TEvent>(this IEventPublisher publisher,
+                                                                         IList<EventContext<TEvent>> events,
+                                                                         TimeSpan delay,
+                                                                         CancellationToken cancellationToken = default)
             where TEvent : class
         {
             var scheduled = DateTimeOffset.UtcNow + delay;
@@ -57,10 +57,10 @@ namespace Tingle.EventBus
         /// <param name="delay">The duration of time to wait before the event is available on the bus for consumption.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static Task<string?> PublishAsync<TEvent>(this IEventPublisher publisher,
-                                                         TEvent @event,
-                                                         TimeSpan delay,
-                                                         CancellationToken cancellationToken = default)
+        public static Task<ScheduledResult?> PublishAsync<TEvent>(this IEventPublisher publisher,
+                                                                  TEvent @event,
+                                                                  TimeSpan delay,
+                                                                  CancellationToken cancellationToken = default)
             where TEvent : class
         {
             var scheduled = DateTimeOffset.UtcNow + delay;
@@ -76,10 +76,10 @@ namespace Tingle.EventBus
         /// <param name="delay">The duration of time to wait before the event is available on the bus for consumption.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        public static Task<IList<string>?> PublishAsync<TEvent>(this IEventPublisher publisher,
-                                                                IList<TEvent> events,
-                                                                TimeSpan delay,
-                                                                CancellationToken cancellationToken = default)
+        public static Task<IList<ScheduledResult>?> PublishAsync<TEvent>(this IEventPublisher publisher,
+                                                                         IList<TEvent> events,
+                                                                         TimeSpan delay,
+                                                                         CancellationToken cancellationToken = default)
             where TEvent : class
         {
             var scheduled = DateTimeOffset.UtcNow + delay;

--- a/src/Tingle.EventBus/Publisher/IEventPublisherExtensions.cs
+++ b/src/Tingle.EventBus/Publisher/IEventPublisherExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -84,6 +85,39 @@ namespace Tingle.EventBus
         {
             var scheduled = DateTimeOffset.UtcNow + delay;
             return publisher.PublishAsync(events: events, scheduled: scheduled, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Cancel a scheduled event.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="publisher">The <see cref="IEventPublisher"/> to extend.</param>
+        /// <param name="result">The scheduling result.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task CancelAsync<TEvent>(this IEventPublisher publisher,
+                                               ScheduledResult result,
+                                               CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            return publisher.CancelAsync<TEvent>(id: result.Id, cancellationToken: cancellationToken);
+        }
+
+        /// <summary>
+        /// Cancel a batch of scheduled events.
+        /// </summary>
+        /// <typeparam name="TEvent">The event type.</typeparam>
+        /// <param name="publisher">The <see cref="IEventPublisher"/> to extend.</param>
+        /// <param name="results">The scheduling results.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public static Task CancelAsync<TEvent>(this IEventPublisher publisher,
+                                               IList<ScheduledResult> results,
+                                               CancellationToken cancellationToken = default)
+            where TEvent : class
+        {
+            var ids = results.Select(r => r.Id).ToList();
+            return publisher.CancelAsync<TEvent>(ids: ids, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/Tingle.EventBus/Publisher/WrappedEventPublisher.cs
+++ b/src/Tingle.EventBus/Publisher/WrappedEventPublisher.cs
@@ -41,33 +41,33 @@ namespace Tingle.EventBus
         }
 
         /// <inheritdoc/>
-        public Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                  DateTimeOffset? scheduled = null,
-                                                  CancellationToken cancellationToken = default) where TEvent : class
+        public Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                           DateTimeOffset? scheduled = null,
+                                                           CancellationToken cancellationToken = default) where TEvent : class
         {
             return inner.PublishAsync<TEvent>(@event, scheduled, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                         DateTimeOffset? scheduled = null,
-                                                         CancellationToken cancellationToken = default) where TEvent : class
+        public Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                  DateTimeOffset? scheduled = null,
+                                                                  CancellationToken cancellationToken = default) where TEvent : class
         {
             return inner.PublishAsync<TEvent>(@events, scheduled, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<string?> PublishAsync<TEvent>(TEvent @event,
-                                                  DateTimeOffset? scheduled = null,
-                                                  CancellationToken cancellationToken = default) where TEvent : class
+        public Task<ScheduledResult?> PublishAsync<TEvent>(TEvent @event,
+                                                           DateTimeOffset? scheduled = null,
+                                                           CancellationToken cancellationToken = default) where TEvent : class
         {
             return inner.PublishAsync<TEvent>(@event, scheduled, cancellationToken);
         }
 
         /// <inheritdoc/>
-        public Task<IList<string>?> PublishAsync<TEvent>(IList<TEvent> events,
-                                                         DateTimeOffset? scheduled = null,
-                                                         CancellationToken cancellationToken = default) where TEvent : class
+        public Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<TEvent> events,
+                                                                  DateTimeOffset? scheduled = null,
+                                                                  CancellationToken cancellationToken = default) where TEvent : class
         {
             return inner.PublishAsync<TEvent>(@events, scheduled, cancellationToken);
         }

--- a/src/Tingle.EventBus/ScheduledResult.cs
+++ b/src/Tingle.EventBus/ScheduledResult.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tingle.EventBus
+{
+    /// <summary>
+    /// Represents the result from scheduling a delayed event.
+    /// </summary>
+    public struct ScheduledResult
+    {
+        /// <summary>
+        /// Creates and instance of <see cref="ScheduledResult"/>.
+        /// </summary>
+        /// <param name="id">Scheduling identifier returned by transport.</param>
+        /// <param name="scheduled">Time at which the event will be availed by the transport.</param>
+        public ScheduledResult(string id, DateTimeOffset scheduled)
+        {
+            Id = id ?? throw new ArgumentNullException(nameof(id));
+            Scheduled = scheduled;
+        }
+
+        /// <summary>
+        /// Scheduling identifier returned by transport.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// Time at which the event will be availed by the transport.
+        /// </summary>
+        public DateTimeOffset Scheduled { get; set; }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj) => obj is ScheduledResult result && Equals(result);
+
+        /// <inheritdoc/>
+        public bool Equals(ScheduledResult other)
+        {
+            return Id == other.Id &&
+                   EqualityComparer<DateTimeOffset?>.Default.Equals(Scheduled, other.Scheduled);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode() => HashCode.Combine(Id, Scheduled);
+
+        /// <inheritdoc/>
+        public override string ToString() => $"{Id} (Availed at {Scheduled:r})";
+
+        /// <inheritdoc/>
+        public static bool operator ==(ScheduledResult left, ScheduledResult right) => left.Equals(right);
+
+        /// <inheritdoc/>
+        public static bool operator !=(ScheduledResult left, ScheduledResult right) => !(left == right);
+
+        /// <summary>
+        /// Convert <see cref="ScheduledResult"/> to <see cref="string"/>.
+        /// </summary>
+        /// <param name="result"></param>
+        public static implicit operator string(ScheduledResult result) => result.Id;
+
+        /// <summary>
+        /// Deconstruct the result into parts
+        /// </summary>
+        /// <param name="id">See <see cref="Id"/>.</param>
+        /// <param name="scheduled">See <see cref="Scheduled"/>.</param>
+        public void Deconstruct(out string id, out DateTimeOffset scheduled)
+        {
+            id = Id;
+            scheduled = Scheduled;
+        }
+    }
+}

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -72,17 +72,17 @@ namespace Tingle.EventBus.Transports
                                                     CancellationToken cancellationToken = default);
 
         /// <inheritdoc/>
-        public abstract Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                           EventRegistration registration,
-                                                           DateTimeOffset? scheduled = null,
-                                                           CancellationToken cancellationToken = default)
+        public abstract Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                    EventRegistration registration,
+                                                                    DateTimeOffset? scheduled = null,
+                                                                    CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <inheritdoc/>
-        public abstract Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                  EventRegistration registration,
-                                                                  DateTimeOffset? scheduled = null,
-                                                                  CancellationToken cancellationToken = default)
+        public abstract Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                           EventRegistration registration,
+                                                                           DateTimeOffset? scheduled = null,
+                                                                           CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <inheritdoc/>

--- a/src/Tingle.EventBus/Transports/IEventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/IEventBusTransport.cs
@@ -39,10 +39,10 @@ namespace Tingle.EventBus.Transports
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                           EventRegistration registration,
-                                           DateTimeOffset? scheduled = null,
-                                           CancellationToken cancellationToken = default)
+        Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                    EventRegistration registration,
+                                                    DateTimeOffset? scheduled = null,
+                                                    CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
@@ -57,17 +57,17 @@ namespace Tingle.EventBus.Transports
         /// </param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                  EventRegistration registration,
-                                                  DateTimeOffset? scheduled = null,
-                                                  CancellationToken cancellationToken = default)
+        Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                           EventRegistration registration,
+                                                           DateTimeOffset? scheduled = null,
+                                                           CancellationToken cancellationToken = default)
             where TEvent : class;
 
         /// <summary>
         /// Cancel a scheduled event on the transport.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="id">The identifier of the scheduled event.</param>
+        /// <param name="id">The scheduling identifier of the scheduled event.</param>
         /// <param name="registration">The registration for the event.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
@@ -80,7 +80,7 @@ namespace Tingle.EventBus.Transports
         /// Cancel a batch of scheduled events on the transport.
         /// </summary>
         /// <typeparam name="TEvent">The event type.</typeparam>
-        /// <param name="ids">The identifiers of the scheduled events.</param>
+        /// <param name="ids">The scheduling identifiers of the scheduled events.</param>
         /// <param name="registration">The registration for the events.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
@@ -117,10 +117,10 @@ namespace Tingle.EventBus.Transports.InMemory
         }
 
         /// <inheritdoc/>
-        public override async Task<string?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                 EventRegistration registration,
-                                                                 DateTimeOffset? scheduled = null,
-                                                                 CancellationToken cancellationToken = default)
+        public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
+                                                                          EventRegistration registration,
+                                                                          DateTimeOffset? scheduled = null,
+                                                                          CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled message
             if (scheduled != null)
@@ -164,7 +164,7 @@ namespace Tingle.EventBus.Transports.InMemory
                     queueEntity.Enqueue(msg);
                     return Task.CompletedTask;
                 }, message);
-                return sng.Generate();
+                return new ScheduledResult(id: sng.Generate(), scheduled: scheduled.Value);
             }
             else
             {
@@ -174,10 +174,10 @@ namespace Tingle.EventBus.Transports.InMemory
         }
 
         /// <inheritdoc/>
-        public async override Task<IList<string>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                       EventRegistration registration,
-                                                                       DateTimeOffset? scheduled = null,
-                                                                       CancellationToken cancellationToken = default)
+        public async override Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                 EventRegistration registration,
+                                                                                 DateTimeOffset? scheduled = null,
+                                                                                 CancellationToken cancellationToken = default)
         {
             // log warning when trying to publish scheduled message
             if (scheduled != null)
@@ -229,12 +229,12 @@ namespace Tingle.EventBus.Transports.InMemory
                     queueEntity.EnqueueBatch(msgs);
                     return Task.CompletedTask;
                 }, messages);
-                return events.Select(_ => sng.Generate()).ToList();
+                return events.Select(_ => new ScheduledResult(id: sng.Generate(), scheduled: scheduled.Value)).ToList();
             }
             else
             {
                 queueEntity.EnqueueBatch(messages);
-                return Array.Empty<string>(); // no sequence numbers available
+                return Array.Empty<ScheduledResult>(); // no sequence numbers available
             }
         }
 


### PR DESCRIPTION
Added `ScheduledResult` to be the return type for `PublishAsync(...)` methods. Hence allow the specifics to be stored by the caller.