### PR TITLE
Use BinaryData

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/BinaryDataExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/BinaryDataExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+
+namespace System
+{
+    /// <summary>
+    /// Extension methods for <see cref="BinaryData"/>
+    /// </summary>
+    internal static class BinaryDataExtensions
+    {
+        /// <summary>
+        /// Converts the <see cref="BinaryData"/> to a <see cref="MemoryStream"/>.
+        /// </summary>
+        /// <param name="data">The <see cref="BinaryData"/> to be converted.</param>
+        /// <returns>A <see cref="MemoryStream"/> representing the data.</returns>
+        public static MemoryStream ToMemoryStream(this BinaryData data) => new MemoryStream(data.ToArray());
+    }
+}

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -391,13 +391,12 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs
             activity?.AddTag(ActivityTagNames.MessagingUrl, queueUrl);
 
             Logger.LogDebug("Processing '{MessageId}' from '{QueueUrl}'", messageId, queueUrl);
-            using var ms = new BinaryData(message.Body).ToStream();
             message.TryGetAttribute("Content-Type", out var contentType_str);
             var contentType = contentType_str == null ? null : new ContentType(contentType_str);
 
             using var scope = CreateScope();
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: new BinaryData(message.Body),
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: messageId,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -150,7 +150,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                                  registration: registration,
                                  cancellationToken: cancellationToken);
 
-            var data = new EventData(ms.ToArray());
+            var data = new EventData(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken));
             data.Properties.AddIfNotDefault(AttributeNames.Id, @event.Id)
                            .AddIfNotDefault(AttributeNames.CorrelationId, @event.CorrelationId)
                            .AddIfNotDefault(AttributeNames.ContentType, @event.ContentType?.ToString())
@@ -201,7 +201,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                                      registration: registration,
                                      cancellationToken: cancellationToken);
 
-                var data = new EventData(ms.ToArray());
+                var data = new EventData(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken));
                 data.Properties.AddIfNotDefault(AttributeNames.Id, @event.Id)
                                .AddIfNotDefault(AttributeNames.CorrelationId, @event.CorrelationId)
                                .AddIfNotDefault(AttributeNames.ContentType, @event.ContentType?.ToString())
@@ -421,7 +421,7 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                             processor.EventHubName,
                             processor.ConsumerGroup);
             using var scope = CreateScope();
-            using var ms = new MemoryStream(data.Body.ToArray());
+            using var ms = new BinaryData(data.Body).ToStream();
             var contentType = contentType_str == null ? null : new ContentType(contentType_str.ToString());
             var context = await DeserializeAsync<TEvent>(scope: scope,
                                                          body: ms,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading;
@@ -143,14 +142,12 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
             }
 
             using var scope = CreateScope();
-            using var ms = new MemoryStream();
-            await SerializeAsync(scope: scope,
-                                 body: ms,
-                                 @event: @event,
-                                 registration: registration,
-                                 cancellationToken: cancellationToken);
+            var body = await SerializeAsync(scope: scope,
+                                            @event: @event,
+                                            registration: registration,
+                                            cancellationToken: cancellationToken);
 
-            var data = new EventData(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken));
+            var data = new EventData(body);
             data.Properties.AddIfNotDefault(AttributeNames.Id, @event.Id)
                            .AddIfNotDefault(AttributeNames.CorrelationId, @event.CorrelationId)
                            .AddIfNotDefault(AttributeNames.ContentType, @event.ContentType?.ToString())
@@ -194,14 +191,12 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
             var datas = new List<EventData>();
             foreach (var @event in events)
             {
-                using var ms = new MemoryStream();
-                await SerializeAsync(scope: scope,
-                                     body: ms,
-                                     @event: @event,
-                                     registration: registration,
-                                     cancellationToken: cancellationToken);
+                var body = await SerializeAsync(scope: scope,
+                                                @event: @event,
+                                                registration: registration,
+                                                cancellationToken: cancellationToken);
 
-                var data = new EventData(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken));
+                var data = new EventData(body);
                 data.Properties.AddIfNotDefault(AttributeNames.Id, @event.Id)
                                .AddIfNotDefault(AttributeNames.CorrelationId, @event.CorrelationId)
                                .AddIfNotDefault(AttributeNames.ContentType, @event.ContentType?.ToString())

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -421,10 +421,9 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs
                             processor.EventHubName,
                             processor.ConsumerGroup);
             using var scope = CreateScope();
-            using var ms = new BinaryData(data.Body).ToStream();
             var contentType = contentType_str == null ? null : new ContentType(contentType_str.ToString());
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: data.EventBody,
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: data.SequenceNumber.ToString(),

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -351,9 +351,8 @@ namespace Tingle.EventBus.Transports.Azure.QueueStorage
             activity?.AddTag(ActivityTagNames.MessagingDestinationKind, "queue");
 
             Logger.LogDebug("Processing '{MessageId}' from '{QueueName}'", messageId, queueClient.Name);
-            using var ms = new BinaryData(message.MessageText).ToStream();
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms, // There is no way to get this yet
+                                                         body: message.Body,
                                                          contentType: null,
                                                          registration: reg,
                                                          identifier: (AzureQueueStorageSchedulingId)message,

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading;
@@ -148,14 +147,12 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                                                                           CancellationToken cancellationToken = default)
         {
             using var scope = CreateScope();
-            using var ms = new MemoryStream();
-            await SerializeAsync(scope: scope,
-                                 body: ms,
-                                 @event: @event,
-                                 registration: registration,
-                                 cancellationToken: cancellationToken);
+            var body = await SerializeAsync(scope: scope,
+                                            @event: @event,
+                                            registration: registration,
+                                            cancellationToken: cancellationToken);
 
-            var message = new ServiceBusMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
+            var message = new ServiceBusMessage(body)
             {
                 MessageId = @event.Id,
                 ContentType = @event.ContentType?.ToString(),
@@ -215,14 +212,12 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
             var messages = new List<ServiceBusMessage>();
             foreach (var @event in events)
             {
-                using var ms = new MemoryStream();
-                await SerializeAsync(scope: scope,
-                                     body: ms,
-                                     @event: @event,
-                                     registration: registration,
-                                     cancellationToken: cancellationToken);
+                var body = await SerializeAsync(scope: scope,
+                                                @event: @event,
+                                                registration: registration,
+                                                cancellationToken: cancellationToken);
 
-                var message = new ServiceBusMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
+                var message = new ServiceBusMessage(body)
                 {
                     MessageId = @event.Id,
                     ContentType = @event.ContentType?.ToString(),

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -581,10 +581,9 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
 
             Logger.LogDebug("Processing '{MessageId}' from '{EntityPath}'", messageId, entityPath);
             using var scope = CreateScope();
-            using var ms = message.Body.ToStream();
             var contentType = new ContentType(message.ContentType);
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: message.Body,
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: message.SequenceNumber.ToString(),

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -155,7 +155,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                                  registration: registration,
                                  cancellationToken: cancellationToken);
 
-            var message = new ServiceBusMessage(ms.ToArray())
+            var message = new ServiceBusMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
             {
                 MessageId = @event.Id,
                 ContentType = @event.ContentType?.ToString(),
@@ -222,7 +222,7 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus
                                      registration: registration,
                                      cancellationToken: cancellationToken);
 
-                var message = new ServiceBusMessage(ms.ToArray())
+                var message = new ServiceBusMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
                 {
                     MessageId = @event.Id,
                     ContentType = @event.ContentType?.ToString(),

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading;
@@ -132,12 +131,10 @@ namespace Tingle.EventBus.Transports.Kafka
             }
 
             using var scope = CreateScope();
-            using var ms = new MemoryStream();
-            await SerializeAsync(scope: scope,
-                                 body: ms,
-                                 @event: @event,
-                                 registration: registration,
-                                 cancellationToken: cancellationToken);
+            var body = await SerializeAsync(scope: scope,
+                                            @event: @event,
+                                            registration: registration,
+                                            cancellationToken: cancellationToken);
 
             // prepare the message
             var message = new Message<string, byte[]>();
@@ -147,7 +144,7 @@ namespace Tingle.EventBus.Transports.Kafka
                            .AddIfNotNull(AttributeNames.InitiatorId, @event.InitiatorId)
                            .AddIfNotNull(AttributeNames.ActivityId, Activity.Current?.Id);
             message.Key = @event.Id!;
-            message.Value = ms.ToArray();
+            message.Value = body.ToArray();
 
             // send the event
             var topic = registration.EventName;
@@ -179,12 +176,10 @@ namespace Tingle.EventBus.Transports.Kafka
             // work on each event
             foreach (var @event in events)
             {
-                using var ms = new MemoryStream();
-                await SerializeAsync(scope: scope,
-                                     body: ms,
-                                     @event: @event,
-                                     registration: registration,
-                                     cancellationToken: cancellationToken);
+                var body = await SerializeAsync(scope: scope,
+                                                @event: @event,
+                                                registration: registration,
+                                                cancellationToken: cancellationToken);
 
                 // prepare the message
                 var message = new Message<string, byte[]>();
@@ -194,7 +189,7 @@ namespace Tingle.EventBus.Transports.Kafka
                                .AddIfNotNull(AttributeNames.InitiatorId, @event.InitiatorId)
                                .AddIfNotNull(AttributeNames.ActivityId, Activity.Current?.Id);
                 message.Key = @event.Id!;
-                message.Value = ms.ToArray();
+                message.Value = body.ToArray();
 
                 // send the event
                 var topic = registration.EventName;

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -304,10 +304,9 @@ namespace Tingle.EventBus.Transports.Kafka
 
             Logger.LogDebug("Processing '{MessageKey}", messageKey);
             using var scope = CreateScope();
-            using var ms = new MemoryStream(message.Value);
             var contentType = contentType_str == null ? null : new ContentType(contentType_str.ToString());
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: new BinaryData(message.Value),
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: result.Offset.ToString(),

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -336,10 +336,9 @@ namespace Tingle.EventBus.Transports.RabbitMQ
 
             Logger.LogDebug("Processing '{MessageId}'", messageId);
             using var scope = CreateScope();
-            using var ms = new BinaryData(args.Body).ToStream();
             var contentType = GetContentType(args.BasicProperties);
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: new BinaryData(args.Body),
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: messageId,

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -68,7 +68,7 @@ namespace Tingle.EventBus.Serialization
             }
 
             // Deserialize
-            var stream = context.Stream;
+            using var stream = context.Body.ToStream();
             var envelope = await DeserializeToEnvelopeAsync<T>(stream: stream, contentType: contentType, cancellationToken: cancellationToken);
             if (envelope is null)
             {

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -119,6 +119,9 @@ namespace Tingle.EventBus.Serialization
 
             // Serialize
             await SerializeEnvelopeAsync(stream: stream, envelope: envelope, cancellationToken: cancellationToken);
+
+            // Return to the begining of the stream
+            stream.Seek(0, SeekOrigin.Begin);
         }
 
         /// <summary>

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Net.Mime;
 using Tingle.EventBus.Registrations;
 
@@ -16,12 +15,10 @@ namespace Tingle.EventBus.Serialization
         /// <param name="body">The <see cref="BinaryData"/> containing the raw data.</param>
         /// <param name="registration">Registration for this event being deserialized.</param>
         /// <param name="identifier">Identifier given the transport for the event to be deserialized.</param>
-        public DeserializationContext(BinaryData body,
-                                      EventRegistration registration,
-                                      string? identifier = null)
+        public DeserializationContext(BinaryData body, EventRegistration registration, string? identifier = null)
         {
             Body = body ?? throw new ArgumentNullException(nameof(body));
-            Registration = registration;
+            Registration = registration ?? throw new ArgumentNullException(nameof(registration));
             Identifier = identifier;
         }
 

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -13,30 +13,22 @@ namespace Tingle.EventBus.Serialization
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="stream">
-        /// The <see cref="System.IO.Stream"/> containing the raw data.
-        /// (It must be readable, i.e. <see cref="Stream.CanRead"/> must be true).
-        /// </param>
+        /// <param name="body">The <see cref="BinaryData"/> containing the raw data.</param>
         /// <param name="registration">Registration for this event being deserialized.</param>
         /// <param name="identifier">Identifier given the transport for the event to be deserialized.</param>
-        public DeserializationContext(Stream stream,
+        public DeserializationContext(BinaryData body,
                                       EventRegistration registration,
                                       string? identifier = null)
         {
-            Stream = stream ?? throw new ArgumentNullException(nameof(stream));
-            if (!stream.CanRead)
-            {
-                throw new InvalidOperationException("The supplied stream must be readable");
-            }
-
+            Body = body ?? throw new ArgumentNullException(nameof(body));
             Registration = registration;
             Identifier = identifier;
         }
 
         /// <summary>
-        /// The <see cref="System.IO.Stream"/> containing the raw data.
+        /// The <see cref="BinaryData"/> containing the raw data.
         /// </summary>
-        public Stream Stream { get; }
+        public BinaryData Body { get; }
 
         /// <summary>
         /// Registration for this event being deserialized.

--- a/src/Tingle.EventBus/Serialization/IEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/IEventSerializer.cs
@@ -1,5 +1,4 @@
 ﻿using System.IO;
-using System.Net.Mime;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/Tingle.EventBus/Serialization/IEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/IEventSerializer.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Tingle.EventBus.Serialization
@@ -13,16 +12,10 @@ namespace Tingle.EventBus.Serialization
         /// Serialize an event into a stream of bytes.
         /// </summary>
         /// <typeparam name="T">The event type to be serialized.</typeparam>
-        /// <param name="stream">
-        /// The stream to serialize to.
-        /// (It must be writeable, i.e. <see cref="Stream.CanWrite"/> must be true).
-        /// </param>
-        /// <param name="context">The context of the event to be serialized.</param>
+        /// <param name="context">The <see cref="SerializationContext{T}"/> to use.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task SerializeAsync<T>(Stream stream,
-                               EventContext<T> context,
-                               CancellationToken cancellationToken = default) where T : class;
+        Task SerializeAsync<T>(SerializationContext<T> context, CancellationToken cancellationToken = default) where T : class;
 
         /// <summary>
         /// Deserialize an event from a stream of bytes.
@@ -31,7 +24,6 @@ namespace Tingle.EventBus.Serialization
         /// <param name="context">The <see cref="DeserializationContext"/> to use.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context,
-                                                   CancellationToken cancellationToken = default) where T : class;
+        Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class;
     }
 }

--- a/src/Tingle.EventBus/Serialization/SerializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/SerializationContext.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Tingle.EventBus.Registrations;
+
+namespace Tingle.EventBus.Serialization
+{
+    /// <summary>
+    /// Context for performing serialization.
+    /// </summary>
+    public class SerializationContext<T> where T : class
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="event">The event to be serialized.</param>
+        /// <param name="registration">Registration for this event being deserialized.</param>
+        public SerializationContext(EventContext<T> @event, EventRegistration registration)
+        {
+            Registration = registration ?? throw new ArgumentNullException(nameof(registration));
+            Event = @event ?? throw new ArgumentNullException(nameof(@event));
+        }
+
+        /// <summary>
+        /// The event to be serialized.
+        /// </summary>
+        public EventContext<T> Event { get; }
+
+        /// <summary>
+        /// The <see cref="BinaryData"/> containing the raw data.
+        /// </summary>
+        public BinaryData? Body { get; internal set; }
+
+        /// <summary>
+        /// Registration for this event being deserialized.
+        /// </summary>
+        public EventRegistration Registration { get; }
+    }
+}

--- a/src/Tingle.EventBus/Tingle.EventBus.csproj
+++ b/src/Tingle.EventBus/Tingle.EventBus.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.9" />
     <PackageReference Include="Polly" Version="7.2.2" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
+    <PackageReference Include="System.Memory.Data" Version="1.0.2" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -165,17 +165,14 @@ namespace Tingle.EventBus.Transports
         /// </summary>
         /// <typeparam name="TEvent">The event type to be deserialized.</typeparam>
         /// <param name="scope">The scope in which to resolve required services.</param>
-        /// <param name="body">
-        /// The <see cref="Stream"/> containing the raw data.
-        /// (It must be readable, i.e. <see cref="Stream.CanRead"/> must be true).
-        /// </param>
+        /// <param name="body">The <see cref="BinaryData"/> containing the raw data.</param>
         /// <param name="contentType">The type of content contained in the <paramref name="body"/>.</param>
         /// <param name="registration">The bus registration for this event.</param>
         /// <param name="identifier">Identifier given the transport for the event to be deserialized.</param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         protected async Task<EventContext<TEvent>> DeserializeAsync<TEvent>(IServiceScope scope,
-                                                                            Stream body,
+                                                                            BinaryData body,
                                                                             ContentType? contentType,
                                                                             EventRegistration registration,
                                                                             string? identifier,

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryQueueMessage.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryQueueMessage.cs
@@ -5,14 +5,77 @@ namespace Tingle.EventBus.Transports.InMemory
 {
     internal class InMemoryQueueMessage
     {
+        /// <summary>
+        /// Creates a new message.
+        /// </summary>
         public InMemoryQueueMessage() { }
-        public InMemoryQueueMessage(ReadOnlyMemory<byte> body) : this() => Body = body;
-        public InMemoryQueueMessage(byte[] body) : this(new ReadOnlyMemory<byte>(body)) { }
 
+        /// <summary>
+        /// Creates a new message from the specified string, using UTF-8 encoding.
+        /// </summary>
+        /// <param name="body">The payload of the message as a string.</param>
+        public InMemoryQueueMessage(string body) : this(BinaryData.FromString(body)) { }
+
+        /// <summary>
+        /// Creates a new message from the specified payload.
+        /// </summary>
+        /// <param name="body">The payload of the message in bytes.</param>
+        public InMemoryQueueMessage(byte[] body) : this(BinaryData.FromBytes(body)) { }
+
+        /// <summary>
+        /// Creates a new message from specified <see cref="BinaryData"/> instance.
+        /// </summary>
+        /// <param name="body">The payload of the message.</param>
+        public InMemoryQueueMessage(BinaryData body)
+        {
+            Body = body;
+        }
+
+        /// <summary>
+        /// Gets or sets the content type descriptor.
+        /// </summary>
+        /// <value>RFC2045 Content-Type descriptor.</value>
+        /// <remarks>
+        /// Optionally describes the payload of the message, with a descriptor
+        /// following the format of RFC2045, Section 5, for example "application/json".
+        /// </remarks>
         public string? ContentType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the a correlation identifier.
+        /// </summary>
+        /// <value>Correlation identifier.</value>
+        /// <remarks>
+        /// Allows an application to specify a context for the message for the
+        /// purposes of correlation, for example reflecting the <see cref="MessageId"/>
+        /// of a message that is being replied to.
+        /// </remarks>
         public string? CorrelationId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the MessageId to identify the message.
+        /// </summary>
+        /// <remarks>
+        /// The message identifier is an application-defined value that uniquely
+        /// identifies the message and its payload. The identifier is a free-form
+        /// string and can reflect a GUID or an identifier derived from the
+        /// application context.
+        /// </remarks>
         public string? MessageId { get; set; }
-        public ReadOnlyMemory<byte> Body { get; set; }
+
+        /// <summary>
+        /// Gets or sets the body of the message.
+        /// </summary>
+        public BinaryData? Body { get; set; }
+
+        /// <summary>
+        /// Gets the application properties bag, which can be used for custom message metadata.
+        /// </summary>
+        /// <remarks>
+        /// Only following value types are supported: byte, sbyte, char, short, ushort, int, uint,
+        /// long, ulong, float, double, decimal, bool, Guid, string, Uri, DateTime, DateTimeOffset,
+        /// TimeSpan
+        /// </remarks>
         public IDictionary<string, object> Properties { get; set; } = new Dictionary<string, object>();
     }
 }

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
@@ -136,7 +136,7 @@ namespace Tingle.EventBus.Transports.InMemory
                                  registration: registration,
                                  cancellationToken: cancellationToken);
 
-            var message = new InMemoryQueueMessage(ms.ToArray())
+            var message = new InMemoryQueueMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
             {
                 MessageId = @event.Id,
                 ContentType = @event.ContentType?.ToString(),
@@ -197,7 +197,7 @@ namespace Tingle.EventBus.Transports.InMemory
                                      registration: registration,
                                      cancellationToken: cancellationToken);
 
-                var message = new InMemoryQueueMessage(ms.ToArray())
+                var message = new InMemoryQueueMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
                 {
                     MessageId = @event.Id,
                     CorrelationId = @event.CorrelationId,
@@ -338,7 +338,7 @@ namespace Tingle.EventBus.Transports.InMemory
             activity?.AddTag(ActivityTagNames.MessagingDestinationKind, "queue");
 
             Logger.LogDebug("Processing '{MessageId}' from '{QueueName}'", messageId, queueEntity.Name);
-            using var ms = new MemoryStream(message.Body.ToArray());
+            using var ms = message.Body!.ToStream();
             var contentType = new ContentType(message.ContentType);
             var context = await DeserializeAsync<TEvent>(scope: scope,
                                                          body: ms,

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
@@ -338,10 +338,9 @@ namespace Tingle.EventBus.Transports.InMemory
             activity?.AddTag(ActivityTagNames.MessagingDestinationKind, "queue");
 
             Logger.LogDebug("Processing '{MessageId}' from '{QueueName}'", messageId, queueEntity.Name);
-            using var ms = message.Body!.ToStream();
             var contentType = new ContentType(message.ContentType);
             var context = await DeserializeAsync<TEvent>(scope: scope,
-                                                         body: ms,
+                                                         body: message.Body!,
                                                          contentType: contentType,
                                                          registration: reg,
                                                          identifier: messageId,

--- a/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus/Transports/InMemory/InMemoryTransport.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading;
@@ -129,14 +128,12 @@ namespace Tingle.EventBus.Transports.InMemory
             }
 
             using var scope = CreateScope();
-            using var ms = new MemoryStream();
-            await SerializeAsync(scope: scope,
-                                 body: ms,
-                                 @event: @event,
-                                 registration: registration,
-                                 cancellationToken: cancellationToken);
+            var body = await SerializeAsync(scope: scope,
+                                            @event: @event,
+                                            registration: registration,
+                                            cancellationToken: cancellationToken);
 
-            var message = new InMemoryQueueMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
+            var message = new InMemoryQueueMessage(body)
             {
                 MessageId = @event.Id,
                 ContentType = @event.ContentType?.ToString(),
@@ -190,14 +187,12 @@ namespace Tingle.EventBus.Transports.InMemory
 
             foreach (var @event in events)
             {
-                using var ms = new MemoryStream();
-                await SerializeAsync(scope: scope,
-                                     body: ms,
-                                     @event: @event,
-                                     registration: registration,
-                                     cancellationToken: cancellationToken);
+                var body = await SerializeAsync(scope: scope,
+                                                @event: @event,
+                                                registration: registration,
+                                                cancellationToken: cancellationToken);
 
-                var message = new InMemoryQueueMessage(await BinaryData.FromStreamAsync(ms, cancellationToken: cancellationToken))
+                var message = new InMemoryQueueMessage(body)
                 {
                     MessageId = @event.Id,
                     CorrelationId = @event.CorrelationId,

--- a/tests/Tingle.EventBus.Tests/Configurator/FakeEventSerializer1.cs
+++ b/tests/Tingle.EventBus.Tests/Configurator/FakeEventSerializer1.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Tingle.EventBus.Serialization;
@@ -9,16 +8,13 @@ namespace Tingle.EventBus.Tests.Configurator
     internal class FakeEventSerializer1 : IEventSerializer
     {
         /// <inheritdoc/>
-        public Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context,
-                                                          CancellationToken cancellationToken = default) where T : class
+        public Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class
         {
             throw new NotImplementedException();
         }
 
         /// <inheritdoc/>
-        public Task SerializeAsync<T>(Stream stream,
-                                      EventContext<T> context,
-                                      CancellationToken cancellationToken = default) where T : class
+        public Task SerializeAsync<T>(SerializationContext<T> context, CancellationToken cancellationToken = default) where T : class
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
Make changes to pass instances of `BinaryData` instead of `Stream` or `byte[]`. This provides additional functionality and improved usability for common scenarios. This necessitated the creation of `SerializationContext<T>`