### PR TITLE
Retryable event

### DIFF
--- a/src/Tingle.EventBus/Retries/AbstractRetryableEvent.cs
+++ b/src/Tingle.EventBus/Retries/AbstractRetryableEvent.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tingle.EventBus.Retries
+{
+    /// <summary>Abstract implementation of <see cref="IRetryableEvent"/>.</summary>
+    public abstract record AbstractRetryableEvent : IRetryableEvent
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        protected AbstractRetryableEvent() { }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="delays">Value for <see cref="Delays"/>.</param>
+        protected AbstractRetryableEvent(IList<TimeSpan> delays)
+        {
+            Delays = delays ?? throw new ArgumentNullException(nameof(delays));
+            if (delays.Count == 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(delays), "You must have at least one delay entry.");
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="delays">Value for <see cref="Delays"/>.</param>
+        /// <param name="attempts">Value for <see cref="Attempts"/>.</param>
+        protected AbstractRetryableEvent(IList<TimeSpan> delays, IList<DateTimeOffset> attempts) : this(delays)
+        {
+            Attempts = attempts ?? throw new ArgumentNullException(nameof(attempts));
+        }
+
+        /// <inheritdoc/>
+        public IList<TimeSpan> Delays { get; set; } = new List<TimeSpan>();
+
+        /// <inheritdoc/>
+        public IList<DateTimeOffset> Attempts { get; set; } = new List<DateTimeOffset>();
+    }
+}

--- a/src/Tingle.EventBus/Retries/IRetryableEvent.cs
+++ b/src/Tingle.EventBus/Retries/IRetryableEvent.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Tingle.EventBus.Retries
+{
+    /// <summary>
+    /// Represents an event (or command) that can be retried and carries its own retry schedule.
+    /// </summary>
+    public interface IRetryableEvent
+    {
+        /// <summary>List of delays to be used for this command.</summary>
+        IList<TimeSpan> Delays { get; set; }
+
+        /// <summary>List of previous attempts.</summary>
+        IList<DateTimeOffset> Attempts { get; set; }
+    }
+}

--- a/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
+++ b/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Polly.Contrib.WaitAndRetry;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Tingle.EventBus.Retries
@@ -142,6 +143,25 @@ namespace Tingle.EventBus.Retries
             if (@event.Attempts is null) throw new ArgumentNullException(nameof(@event.Attempts));
 
             return (@event.Delays.Count - @event.Attempts.Count) == 1;
+        }
+
+        /// <summary>Trys to get the delay for the next retry if any.</summary>
+        /// <param name="event"></param>
+        /// <param name="delay"></param>
+        /// <returns></returns>
+        public static bool TryGetNextRetryDelay(this IRetryableEvent @event, [NotNullWhen(true)] out TimeSpan? delay)
+        {
+            var attempts = @event.Attempts;
+            var delays = @event.Delays;
+
+            if (attempts.Count >= (delays.Count + 1))
+            {
+                delay = null;
+                return false;
+            }
+
+            delay = @event.Delays.Skip(attempts.Count - 1).First();
+            return true;
         }
 
         #endregion

--- a/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
+++ b/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
@@ -16,7 +16,7 @@ namespace Tingle.EventBus.Retries
         /// For example: 850ms, 1455ms, 3060ms. 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <param name="medianFirstRetryDelay">
         /// The median delay to target before the first retry, call it f (= f * 2^0).
         /// Choose this value both to approximate the first delay, and to scale the remainder of the series.
@@ -32,14 +32,14 @@ namespace Tingle.EventBus.Retries
         /// </param>
         /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
         /// <returns></returns>
-        public static T WithJitterDelays<T>(this T command, TimeSpan medianFirstRetryDelay, int retries, int? seed = null, bool fastFirst = false)
+        public static T WithJitterDelays<T>(this T @event, TimeSpan medianFirstRetryDelay, int retries, int? seed = null, bool fastFirst = false)
             where T : IRetryableEvent
         {
             var delays = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: medianFirstRetryDelay,
                                                              retryCount: retries,
                                                              seed: seed,
                                                              fastFirst: fastFirst);
-            return command.WithDelays(delays);
+            return @event.WithDelays(delays);
         }
 
         /// <summary>
@@ -48,17 +48,17 @@ namespace Tingle.EventBus.Retries
         /// For example: 100ms, 200ms, 400ms, 800ms, ...
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <param name="initialDelay">The duration value for the wait before the first retry.</param>
         /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
         /// <param name="factor">The exponent to multiply each subsequent duration by.</param>
         /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
         /// <returns></returns>
-        public static T WithExponentialDelays<T>(this T command, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
+        public static T WithExponentialDelays<T>(this T @event, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
             where T : IRetryableEvent
         {
             var delays = Backoff.ExponentialBackoff(initialDelay: initialDelay, retryCount: retries, factor: factor, fastFirst: fastFirst);
-            return command.WithDelays(delays);
+            return @event.WithDelays(delays);
         }
 
         /// <summary>
@@ -67,17 +67,17 @@ namespace Tingle.EventBus.Retries
         /// For example: 100ms, 200ms, 300ms, 400ms, ...
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <param name="initialDelay">The duration value for the first retry.</param>
         /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
         /// <param name="factor">The linear factor to use for increasing the duration on subsequent calls.</param>
         /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
         /// <returns></returns>
-        public static T WithLinearDelays<T>(this T command, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
+        public static T WithLinearDelays<T>(this T @event, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
             where T : IRetryableEvent
         {
             var delays = Backoff.LinearBackoff(initialDelay: initialDelay, retryCount: retries, factor: factor, fastFirst: fastFirst);
-            return command.WithDelays(delays);
+            return @event.WithDelays(delays);
         }
 
         /// <summary>
@@ -86,22 +86,22 @@ namespace Tingle.EventBus.Retries
         /// For example: 200ms, 200ms, 200ms, ...
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <param name="delay">The constant wait duration before each retry.</param>
         /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
         /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
         /// <returns></returns>
-        public static T WithConstantDelays<T>(this T command, TimeSpan delay, int retries, bool fastFirst = false)
+        public static T WithConstantDelays<T>(this T @event, TimeSpan delay, int retries, bool fastFirst = false)
             where T : IRetryableEvent
         {
             var delays = Backoff.ConstantBackoff(delay: delay, retryCount: retries, fastFirst: fastFirst);
-            return command.WithDelays(delays);
+            return @event.WithDelays(delays);
         }
 
-        private static T WithDelays<T>(this T command, IEnumerable<TimeSpan> delays) where T : IRetryableEvent
+        private static T WithDelays<T>(this T @event, IEnumerable<TimeSpan> delays) where T : IRetryableEvent
         {
-            command.Delays = delays.ToList();
-            return command;
+            @event.Delays = delays.ToList();
+            return @event;
         }
 
         #endregion
@@ -112,26 +112,26 @@ namespace Tingle.EventBus.Retries
         /// 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <param name="attempt"></param>
         /// <returns></returns>
-        public static T AddAttempt<T>(this T command, DateTimeOffset attempt) where T : IRetryableEvent
+        public static T AddAttempt<T>(this T @event, DateTimeOffset attempt) where T : IRetryableEvent
         {
-            var attempts = command.Attempts;
+            var attempts = @event.Attempts;
             attempts.Add(attempt);
 
-            return command;
+            return @event;
         }
 
         /// <summary>
         /// 
         /// </summary>
         /// <typeparam name="T"></typeparam>
-        /// <param name="command"></param>
+        /// <param name="event"></param>
         /// <returns></returns>
-        public static T AddAttempt<T>(this T command) where T : IRetryableEvent
+        public static T AddAttempt<T>(this T @event) where T : IRetryableEvent
         {
-            return command.AddAttempt(DateTimeOffset.UtcNow);
+            return @event.AddAttempt(DateTimeOffset.UtcNow);
         }
 
         /// <summary>Whether this event is doing it's last attempt.</summary>

--- a/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
+++ b/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
@@ -1,0 +1,149 @@
+﻿using Polly.Contrib.WaitAndRetry;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Tingle.EventBus.Retries
+{
+    /// <summary>Extension methods for <see cref="IRetryableEvent"/>.</summary>
+    public static class IRetryableEventExtensions
+    {
+        #region Delays
+
+        /// <summary>
+        /// Generates and sets delay durations in an exponentially backing-off, jittered manner, making
+        /// sure to mitigate any correlations.
+        /// For example: 850ms, 1455ms, 3060ms. 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <param name="medianFirstRetryDelay">
+        /// The median delay to target before the first retry, call it f (= f * 2^0).
+        /// Choose this value both to approximate the first delay, and to scale the remainder of the series.
+        /// Subsequent retries will (over a large sample size) have a median approximating retries
+        /// at time f * 2^1, f * 2^2 ... f * 2^t etc for try t.
+        /// The actual amount of delay-before-retry for try t may be distributed between 0 and
+        /// f * (2^(t+1) - 2^(t-1)) for t >= 2; or between 0 and f * 2^(t+1), for t is 0 or 1.
+        /// </param>
+        /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
+        /// <param name="seed">
+        /// An optional System.Random seed to use. If not specified, will use a shared instance
+        /// with a random seed, per Microsoft recommendation for maximum randomness.
+        /// </param>
+        /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
+        /// <returns></returns>
+        public static T WithJitterDelays<T>(this T command, TimeSpan medianFirstRetryDelay, int retries, int? seed = null, bool fastFirst = false)
+            where T : IRetryableEvent
+        {
+            var delays = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: medianFirstRetryDelay,
+                                                             retryCount: retries,
+                                                             seed: seed,
+                                                             fastFirst: fastFirst);
+            return command.WithDelays(delays);
+        }
+
+        /// <summary>
+        /// Generates and sets delay durations in an exponential manner.
+        /// The formula used is: Duration = initialDelay x 2^iteration.
+        /// For example: 100ms, 200ms, 400ms, 800ms, ...
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <param name="initialDelay">The duration value for the wait before the first retry.</param>
+        /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
+        /// <param name="factor">The exponent to multiply each subsequent duration by.</param>
+        /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
+        /// <returns></returns>
+        public static T WithExponentialDelays<T>(this T command, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
+            where T : IRetryableEvent
+        {
+            var delays = Backoff.ExponentialBackoff(initialDelay: initialDelay, retryCount: retries, factor: factor, fastFirst: fastFirst);
+            return command.WithDelays(delays);
+        }
+
+        /// <summary>
+        /// Generates and sets delay durations in an linear manner.
+        /// The formula used is: Duration = initialDelay x (1 + factor x iteration).
+        /// For example: 100ms, 200ms, 300ms, 400ms, ...
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <param name="initialDelay">The duration value for the first retry.</param>
+        /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
+        /// <param name="factor">The linear factor to use for increasing the duration on subsequent calls.</param>
+        /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
+        /// <returns></returns>
+        public static T WithLinearDelays<T>(this T command, TimeSpan initialDelay, int retries, double factor = 2, bool fastFirst = false)
+            where T : IRetryableEvent
+        {
+            var delays = Backoff.LinearBackoff(initialDelay: initialDelay, retryCount: retries, factor: factor, fastFirst: fastFirst);
+            return command.WithDelays(delays);
+        }
+
+        /// <summary>
+        /// Generates and sets delay durations as a constant value.
+        /// The formula used is: Duration = delay.
+        /// For example: 200ms, 200ms, 200ms, ...
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <param name="delay">The constant wait duration before each retry.</param>
+        /// <param name="retries">The maximum number of retries to use, in addition to the original call.</param>
+        /// <param name="fastFirst">Whether the first retry will be immediate or not.</param>
+        /// <returns></returns>
+        public static T WithConstantDelays<T>(this T command, TimeSpan delay, int retries, bool fastFirst = false)
+            where T : IRetryableEvent
+        {
+            var delays = Backoff.ConstantBackoff(delay: delay, retryCount: retries, fastFirst: fastFirst);
+            return command.WithDelays(delays);
+        }
+
+        private static T WithDelays<T>(this T command, IEnumerable<TimeSpan> delays) where T : IRetryableEvent
+        {
+            command.Delays = delays.ToList();
+            return command;
+        }
+
+        #endregion
+
+        #region Attempts
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <param name="attempt"></param>
+        /// <returns></returns>
+        public static T AddAttempt<T>(this T command, DateTimeOffset attempt) where T : IRetryableEvent
+        {
+            var attempts = command.Attempts;
+            attempts.Add(attempt);
+
+            return command;
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="command"></param>
+        /// <returns></returns>
+        public static T AddAttempt<T>(this T command) where T : IRetryableEvent
+        {
+            return command.AddAttempt(DateTimeOffset.UtcNow);
+        }
+
+        /// <summary>Whether this event is doing it's last attempt.</summary>
+        public static bool IsLastAttempt(this IRetryableEvent @event)
+        {
+            if (@event is null) throw new ArgumentNullException(nameof(@event));
+            if (@event.Delays is null) throw new ArgumentNullException(nameof(@event.Delays));
+            if (@event.Attempts is null) throw new ArgumentNullException(nameof(@event.Attempts));
+
+            return (@event.Delays.Count - @event.Attempts.Count) == 1;
+        }
+
+        #endregion
+    }
+}

--- a/src/Tingle.EventBus/Tingle.EventBus.csproj
+++ b/src/Tingle.EventBus/Tingle.EventBus.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.9" />
     <PackageReference Include="Polly" Version="7.2.2" />
+    <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" />
     <PackageReference Include="System.Memory.Data" Version="1.0.2" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />


### PR DESCRIPTION
Added common logic for rescheduling events based on a generated schedule to aid in backoff for events. This basically publishes another event with a delay.