### PR TITLE
Mark EventBusHealthCheck as obsolete

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -10,6 +10,7 @@
     </Compile>
 
     <EmbeddedResource Update="Properties\Resources.resx">
+      <DesignTime>True</DesignTime>
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>

--- a/src/Tingle.EventBus/ConstStrings.cs
+++ b/src/Tingle.EventBus/ConstStrings.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Tingle.EventBus
+{
+    internal class ConstStrings
+    {
+        public const string HealthChecksObsolete = "Migrate to AspNetCore.Diagnostics.HealthChecks or build custom health checks for your workflow.";
+    }
+}

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -59,6 +59,7 @@ namespace Tingle.EventBus
         /// <param name="data">Additional key-value pairs describing the health of the bus.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>A value indicating if the bus is healthy.</returns>
+        [Obsolete(ConstStrings.HealthChecksObsolete)]
         public async Task<bool> CheckHealthAsync(Dictionary<string, object> data,
                                                  CancellationToken cancellationToken = default)
         {

--- a/src/Tingle.EventBus/Health/EventBusHealthCheck.cs
+++ b/src/Tingle.EventBus/Health/EventBusHealthCheck.cs
@@ -9,7 +9,7 @@ namespace Tingle.EventBus.Health
     /// <summary>
     /// Implementation of <see cref="IHealthCheck"/> for <see cref="EventBus"/>
     /// </summary>
-    [Obsolete("Migrate to AspNetCore.Diagnostics.HealthChecks or build custom health checks for your workflow.")]
+    [Obsolete(ConstStrings.HealthChecksObsolete)]
     public class EventBusHealthCheck : IHealthCheck
     {
         private readonly EventBus bus;

--- a/src/Tingle.EventBus/Health/EventBusHealthCheck.cs
+++ b/src/Tingle.EventBus/Health/EventBusHealthCheck.cs
@@ -9,6 +9,7 @@ namespace Tingle.EventBus.Health
     /// <summary>
     /// Implementation of <see cref="IHealthCheck"/> for <see cref="EventBus"/>
     /// </summary>
+    [Obsolete("Migrate to AspNetCore.Diagnostics.HealthChecks or build custom health checks for your workflow.")]
     public class EventBusHealthCheck : IHealthCheck
     {
         private readonly EventBus bus;

--- a/src/Tingle.EventBus/Health/IHealthChecksBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Health/IHealthChecksBuilderExtensions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The health check name.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
+        [System.Obsolete("Migrate to AspNetCore.Diagnostics.HealthChecks or build custom health checks for your workflow.")]
         public static IHealthChecksBuilder AddEventBus(this IHealthChecksBuilder builder, string name = "eventbus")
         {
             return builder.AddCheck<EventBusHealthCheck>(name, tags: new[] { "eventbus", });

--- a/src/Tingle.EventBus/Health/IHealthChecksBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Health/IHealthChecksBuilderExtensions.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Extensions.DependencyInjection
         /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
         /// <param name="name">The health check name.</param>
         /// <returns>The <see cref="IHealthChecksBuilder"/>.</returns>
-        [System.Obsolete("Migrate to AspNetCore.Diagnostics.HealthChecks or build custom health checks for your workflow.")]
+        [System.Obsolete(ConstStrings.HealthChecksObsolete)]
         public static IHealthChecksBuilder AddEventBus(this IHealthChecksBuilder builder, string name = "eventbus")
         {
             return builder.AddCheck<EventBusHealthCheck>(name, tags: new[] { "eventbus", });

--- a/src/Tingle.EventBus/Transports/IEventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/IEventBusTransport.cs
@@ -24,6 +24,7 @@ namespace Tingle.EventBus.Transports
         /// <param name="data">Additional key-value pairs describing the health of the transport.</param>
         /// <param name="cancellationToken"></param>
         /// <returns>A value indicating if the bus is healthy.</returns>
+        [Obsolete(ConstStrings.HealthChecksObsolete)]
         Task<bool> CheckHealthAsync(Dictionary<string, object> data,
                                     CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
Implementations in [`AspNetCore.Diagnostics.HealthChecks`](https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks) are better for handling multiple scenarios, and they are more stable as compared to those in here. This PR marks health checks stuff obsolete and encourages migration to those packages.
