### PR TITLE
String headers values

### DIFF
--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -350,7 +350,7 @@ namespace Tingle.EventBus.Transports.Azure.QueueStorage
             // if the event contains the parent activity id, set it
             if (context.Headers.TryGetValue(HeaderNames.ActivityId, out var parentActivityId))
             {
-                activity?.SetParentId(parentId: parentActivityId!.ToString());
+                activity?.SetParentId(parentId: parentActivityId);
             }
 
             var (successful, _) = await ConsumeAsync<TEvent, TConsumer>(ecr: ecr,

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -50,7 +50,7 @@ namespace Tingle.EventBus
         /// The headers published alongside the event.
         /// The keys are case insensitive.
         /// </summary>
-        public IDictionary<string, object> Headers { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
         /// The content type used to serialize and deserialize the event to/from a stream of bytes.

--- a/src/Tingle.EventBus/Serialization/EventEnvelope.cs
+++ b/src/Tingle.EventBus/Serialization/EventEnvelope.cs
@@ -27,7 +27,7 @@ namespace Tingle.EventBus.Serialization
         public DateTimeOffset? Sent { get; set; }
 
         /// <inheritdoc/>
-        public IDictionary<string, object> Headers { get; set; } = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
+        public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
         /// <inheritdoc/>
         public HostInfo? Host { get; set; }

--- a/src/Tingle.EventBus/Serialization/IEventEnvelope.cs
+++ b/src/Tingle.EventBus/Serialization/IEventEnvelope.cs
@@ -41,7 +41,7 @@ namespace Tingle.EventBus.Serialization
         /// <summary>
         /// The headers published alongside the event.
         /// </summary>
-        IDictionary<string, object> Headers { get; }
+        IDictionary<string, string> Headers { get; }
 
         /// <summary>
         /// Information about the host on which the event was generated.

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventEnvelope.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventEnvelope.cs
@@ -48,12 +48,12 @@ namespace Tingle.EventBus.Serialization.Xml
 
         /// <inheritdoc/>
         [XmlIgnore]
-        IDictionary<string, object> IEventEnvelope.Headers
+        IDictionary<string, string> IEventEnvelope.Headers
         {
             get
             {
-                var pairs = Headers.Select(h => (KeyValuePair<string, object>)h);
-                return new Dictionary<string, object>(pairs, StringComparer.OrdinalIgnoreCase);
+                var pairs = Headers.Select(h => (KeyValuePair<string, string>)h);
+                return new Dictionary<string, string>(pairs, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/Tingle.EventBus/Serialization/Xml/XmlHeader.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlHeader.cs
@@ -8,28 +8,28 @@ namespace Tingle.EventBus.Serialization.Xml
     public struct XmlHeader
     {
         ///
-        public XmlHeader(string key, object value) : this() { Key = key; Value = value; }
+        public XmlHeader(string key, string value) : this() { Key = key; Value = value; }
 
         ///
         public string Key { get; set; }
 
         ///
-        public object Value { get; set; }
+        public string Value { get; set; }
 
         /// <summary>
         /// Convert <see cref="XmlHeader"/> to <see cref="KeyValuePair{TKey, TValue}"/>.
         /// </summary>
         /// <param name="header"></param>
-        public static implicit operator KeyValuePair<string, object>(XmlHeader header)
+        public static implicit operator KeyValuePair<string, string>(XmlHeader header)
         {
-            return new KeyValuePair<string, object>(header.Key, header.Value);
+            return new KeyValuePair<string, string>(header.Key, header.Value);
         }
 
         /// <summary>
         /// Convert <see cref="KeyValuePair{TKey, TValue}"/> to <see cref="XmlHeader"/>.
         /// </summary>
         /// <param name="pair"></param>
-        public static implicit operator XmlHeader(KeyValuePair<string, object> pair)
+        public static implicit operator XmlHeader(KeyValuePair<string, string> pair)
         {
             return new XmlHeader(pair.Key, pair.Value);
         }


### PR DESCRIPTION
Change the header dictionary values in the `EventContext` and `EventEnvelope` to strings which makes it easier for serialization and moving around.