### PR TITLE
Better serializer resolution

### DIFF
--- a/samples/AzureIotHub/Program.cs
+++ b/samples/AzureIotHub/Program.cs
@@ -12,9 +12,6 @@ var host = Host.CreateDefaultBuilder(args)
 
                        builder.AddConsumer<AzureIotEventsConsumer>();
 
-                       // setup extra serializers
-                       builder.Services.AddSingleton<MyIotHubEventSerializer>();
-
                        // Transport specific configuration
                        builder.AddAzureEventHubsTransport(options =>
                        {

--- a/samples/CustomEventSerializer/Program.cs
+++ b/samples/CustomEventSerializer/Program.cs
@@ -13,9 +13,6 @@ var host = Host.CreateDefaultBuilder(args)
                        });
                        builder.AddConsumer<AzureDevOpsEventsConsumer>();
 
-                       // setup extra serializers
-                       builder.Services.AddSingleton<AzureDevOpsEventSerializer>();
-
                        // Transport specific configuration
                        builder.AddAzureQueueStorageTransport("UseDevelopmentStorage=true;");
                    });

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -133,9 +133,9 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
                                                                         CancellationToken cancellationToken = default)
         where TEvent : class
     {
-        // Get the serializer
+        // Resolve the serializer
         var registration = ctx.Registration;
-        var serializer = (IEventSerializer)ctx.ServiceProvider.GetRequiredService(registration.EventSerializerType!);
+        var serializer = (IEventSerializer)ActivatorUtilities.GetServiceOrCreateInstance(ctx.ServiceProvider, registration.EventSerializerType!);
 
         // Deserialize the content into a context
         var context = await serializer.DeserializeAsync<TEvent>(ctx, cancellationToken);
@@ -186,9 +186,9 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
                                                 CancellationToken cancellationToken = default)
         where TEvent : class
     {
-        // Get the serializer
+        // Resolve the serializer
         var registration = ctx.Registration;
-        var serializer = (IEventSerializer)ctx.ServiceProvider.GetRequiredService(registration.EventSerializerType!);
+        var serializer = (IEventSerializer)ActivatorUtilities.GetServiceOrCreateInstance(ctx.ServiceProvider, registration.EventSerializerType!);
 
         // Serialize
         await serializer.SerializeAsync(ctx, cancellationToken);


### PR DESCRIPTION
Change serializer resolution to use `ActivatorUtilities` instead of pulling from the service provider hence there is no need to register it in the service collection.