### PR TITLE
Access raw transport data in serializers

### DIFF
--- a/samples/AzureIotHub/AzureIotEventsConsumer.cs
+++ b/samples/AzureIotHub/AzureIotEventsConsumer.cs
@@ -1,7 +1,11 @@
-﻿namespace AzureIotHub;
+﻿using System.Text.Json;
+
+namespace AzureIotHub;
 
 internal class AzureIotEventsConsumer : IEventConsumer<MyIotHubEvent>
 {
+    private static readonly JsonSerializerOptions serializerOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true, };
+
     private readonly ILogger logger;
 
     public AzureIotEventsConsumer(ILogger<AzureIotEventsConsumer> logger)
@@ -11,15 +15,18 @@ internal class AzureIotEventsConsumer : IEventConsumer<MyIotHubEvent>
 
     public Task ConsumeAsync(EventContext<MyIotHubEvent> context, CancellationToken cancellationToken)
     {
+        var evt = context.Event;
+
         var deviceId = context.GetIotHubDeviceId();
         var source = context.GetIotHubMessageSource();
         var enqueued = context.GetIotHubEnqueuedTime();
 
-        logger.LogInformation("Received {Source} from {DeviceId}\r\nEnqueued: {EnqueuedTime}\r\nTimestamped: {Timestamp}.",
+        logger.LogInformation("Received {Source} from {DeviceId}\r\nEnqueued: {EnqueuedTime}\r\nTimestamped: {Timestamp}\r\nPayload:{Payload}",
                               source,
                               deviceId,
                               enqueued,
-                              context.Event.Timestamp);
+                              evt.Timestamp,
+                              JsonSerializer.Serialize(evt, serializerOptions));
 
         return Task.CompletedTask;
     }

--- a/samples/AzureIotHub/MyIotHubEventSerializer.cs
+++ b/samples/AzureIotHub/MyIotHubEventSerializer.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Options;
-using System.Net.Mime;
 using System.Text.Json;
 using Tingle.EventBus.Serialization;
 
@@ -16,7 +15,7 @@ internal class MyIotHubEventSerializer : AbstractEventSerializer
 
     /// <inheritdoc/>
     protected override async Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                                    ContentType? contentType,
+                                                                                    DeserializationContext context,
                                                                                     CancellationToken cancellationToken = default)
     {
         var serializerOptions = OptionsAccessor.CurrentValue.SerializerOptions;

--- a/samples/CustomEventSerializer/AzureDevOpsEventSerializer.cs
+++ b/samples/CustomEventSerializer/AzureDevOpsEventSerializer.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using System.Net.Mime;
 using Tingle.EventBus.Serialization;
 
 namespace CustomEventSerializer;
@@ -19,7 +18,7 @@ public class AzureDevOpsEventSerializer : AbstractEventSerializer
 
     /// <inheritdoc/>
     protected override Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                              ContentType? contentType,
+                                                                              DeserializationContext context,
                                                                               CancellationToken cancellationToken = default)
     {
         using var sr = new StreamReader(stream);

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -2,7 +2,6 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
-using System.Net.Mime;
 using System.Text;
 using Tingle.EventBus.Serialization;
 
@@ -35,11 +34,11 @@ public class NewtonsoftJsonSerializer : AbstractEventSerializer
 
     /// <inheritdoc/>
     protected override Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                              ContentType? contentType,
+                                                                              DeserializationContext context,
                                                                               CancellationToken cancellationToken = default)
     {
         // get the encoding and always default to UTF-8
-        var encoding = Encoding.GetEncoding(contentType?.CharSet ?? Encoding.UTF8.BodyName);
+        var encoding = Encoding.GetEncoding(context.ContentType?.CharSet ?? Encoding.UTF8.BodyName);
 
         // Deserialize
         using var sr = new StreamReader(stream: stream,

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -470,6 +470,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: messageId,
+                                                     raw: message,
                                                      cancellationToken: cancellationToken);
 
         Logger.ReceivedMessage(messageId: messageId, eventId: context.Id, queueUrl: queueUrl);

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -411,6 +411,7 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: data.SequenceNumber.ToString(),
+                                                     raw: data,
                                                      cancellationToken: cancellationToken);
         Logger.ReceivedEvent(eventId: context.Id,
                              eventHubName: processor.EventHubName,

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -338,6 +338,7 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
                                                      contentType: null,
                                                      registration: reg,
                                                      identifier: (AzureQueueStorageSchedulingId)message,
+                                                     raw: message,
                                                      cancellationToken: cancellationToken);
 
         Logger.ReceivedMessage(messageId: messageId, eventId: context.Id, queueName: queueClient.Name);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -535,6 +535,7 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: message.SequenceNumber.ToString(),
+                                                     raw: message,
                                                      cancellationToken: cancellationToken);
 
         Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventId: context.Id, entityPath: entityPath);

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -373,6 +373,7 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: message.SequenceNumber.ToString(),
+                                                     raw: message,
                                                      cancellationToken: cancellationToken);
 
         Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventId: context.Id, entityPath: entityPath);

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -290,6 +290,7 @@ public class KafkaTransport : EventBusTransportBase<KafkaTransportOptions>, IDis
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: result.Offset.ToString(),
+                                                     raw: message,
                                                      cancellationToken: cancellationToken);
         Logger.ReceivedEvent(messageKey, context.Id);
         var (successful, _) = await ConsumeAsync<TEvent, TConsumer>(ecr: ecr,

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -317,6 +317,7 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
                                                      contentType: contentType,
                                                      registration: reg,
                                                      identifier: messageId,
+                                                     raw: args,
                                                      cancellationToken: cancellationToken);
         Logger.LogInformation("Received message: '{MessageId}' containing Event '{Id}'",
                               messageId,

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -59,7 +59,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
 
         // Deserialize
         using var stream = context.Body.ToStream();
-        var envelope = await DeserializeToEnvelopeAsync<T>(stream: stream, contentType: contentType, cancellationToken: cancellationToken);
+        var envelope = await DeserializeToEnvelopeAsync<T>(stream: stream, context: context, cancellationToken: cancellationToken);
         if (envelope is null)
         {
             Logger.DeserializationResultedInNull(identifier: context.Identifier, eventType: context.Registration.EventType.FullName);
@@ -127,11 +127,11 @@ public abstract class AbstractEventSerializer : IEventSerializer
     /// The <see cref="Stream"/> containing the raw data.
     /// (It must be readable, i.e. <see cref="Stream.CanRead"/> must be true).
     /// </param>
-    /// <param name="contentType">The type of content contained in the <paramref name="stream"/>.</param>
+    /// <param name="context">The <see cref="DeserializationContext"/> in use.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     protected abstract Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                              ContentType? contentType,
+                                                                              DeserializationContext context,
                                                                               CancellationToken cancellationToken = default)
         where T : class;
 

--- a/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Net.Mime;
 using System.Text.Json;
 
 namespace Tingle.EventBus.Serialization;
@@ -25,7 +24,7 @@ public class DefaultJsonEventSerializer : AbstractEventSerializer
 
     /// <inheritdoc/>
     protected override async Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                                    ContentType? contentType,
+                                                                                    DeserializationContext context,
                                                                                     CancellationToken cancellationToken = default)
     {
         var serializerOptions = OptionsAccessor.CurrentValue.SerializerOptions;

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -45,4 +45,14 @@ public sealed class DeserializationContext
     /// Type of content contained in the <see cref="Body"/>.
     /// </summary>
     public ContentType? ContentType { get; set; }
+
+    /// <summary>
+    /// The raw data provided by the transport without any manipuaation.
+    /// It can be null depending on the transport implementation.
+    /// It is meant to be used by serializers who need context as to what the transport provided.
+    /// <br/>
+    /// For example for Event Hubs this is of type Azure.Messaging.EventHubs.EventData,
+    /// whereas for Service Bus this is of type Azure.Messaging.ServiceBus.ServiceBusMessage.
+    /// </summary>
+    public object? RawTransportData { get; init; }
 }

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -44,7 +44,7 @@ public sealed class DeserializationContext
     /// <summary>
     /// Type of content contained in the <see cref="Body"/>.
     /// </summary>
-    public ContentType? ContentType { get; set; }
+    public ContentType? ContentType { get; init; }
 
     /// <summary>
     /// The raw data provided by the transport without any manipuaation.

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -47,7 +47,7 @@ public sealed class DeserializationContext
     public ContentType? ContentType { get; init; }
 
     /// <summary>
-    /// The raw data provided by the transport without any manipuaation.
+    /// The raw data provided by the transport without any manipulation.
     /// It can be null depending on the transport implementation.
     /// It is meant to be used by serializers who need context as to what the transport provided.
     /// <br/>

--- a/src/Tingle.EventBus/Serialization/EventEnvelope.cs
+++ b/src/Tingle.EventBus/Serialization/EventEnvelope.cs
@@ -6,28 +6,28 @@
 public class EventEnvelope : IEventEnvelope
 {
     /// <inheritdoc/>
-    public string? Id { get; set; }
+    public string? Id { get; init; }
 
     /// <inheritdoc/>
-    public string? RequestId { get; set; }
+    public string? RequestId { get; init; }
 
     /// <inheritdoc/>
-    public string? CorrelationId { get; set; }
+    public string? CorrelationId { get; init; }
 
     /// <inheritdoc/>
-    public string? InitiatorId { get; set; }
+    public string? InitiatorId { get; init; }
 
     /// <inheritdoc/>
-    public DateTimeOffset? Expires { get; set; }
+    public DateTimeOffset? Expires { get; init; }
 
     /// <inheritdoc/>
-    public DateTimeOffset? Sent { get; set; }
+    public DateTimeOffset? Sent { get; init; }
 
     /// <inheritdoc/>
-    public IDictionary<string, string> Headers { get; set; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    public IDictionary<string, string> Headers { get; init; } = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
     /// <inheritdoc/>
-    public HostInfo? Host { get; set; }
+    public HostInfo? Host { get; init; }
 }
 
 /// <summary>
@@ -36,5 +36,5 @@ public class EventEnvelope : IEventEnvelope
 public class EventEnvelope<T> : EventEnvelope, IEventEnvelope<T> where T : class
 {
     /// <inheritdoc/>
-    public T? Event { get; set; }
+    public T? Event { get; init; }
 }

--- a/src/Tingle.EventBus/Serialization/HostInfo.cs
+++ b/src/Tingle.EventBus/Serialization/HostInfo.cs
@@ -9,35 +9,35 @@ public record HostInfo
     /// The machine name (or role instance name) of the machine.
     /// </summary>
     /// <example>WIN-HQ1243</example>
-    public virtual string? MachineName { get; set; }
+    public virtual string? MachineName { get; init; }
 
     /// <summary>
     /// The name of the application.
     /// </summary>
     /// <example>Tingle.EventBus.Examples.SimplePublisher</example>
-    public virtual string? ApplicationName { get; set; }
+    public virtual string? ApplicationName { get; init; }
 
     /// <summary>
     /// The version of the application.
     /// </summary>
     /// <example>1.0.0.0</example>
-    public virtual string? ApplicationVersion { get; set; }
+    public virtual string? ApplicationVersion { get; init; }
 
     /// <summary>
     /// The name of the environment the application is running in.
     /// </summary>
     /// <example>Production</example>
-    public virtual string? EnvironmentName { get; set; }
+    public virtual string? EnvironmentName { get; init; }
 
     /// <summary>
     /// The version of the library.
     /// </summary>
     /// <example>1.0.0.0</example>
-    public virtual string? LibraryVersion { get; set; }
+    public virtual string? LibraryVersion { get; init; }
 
     /// <summary>
     /// The operating system hosting the application.
     /// </summary>
     /// <example>Microsoft Windows NT 10.0.19042.0</example>
-    public virtual string? OperatingSystem { get; set; }
+    public virtual string? OperatingSystem { get; init; }
 }

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializer.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using System.Net.Mime;
 using System.Xml.Serialization;
 
 namespace Tingle.EventBus.Serialization.Xml;
@@ -25,7 +24,7 @@ public class XmlEventSerializer : AbstractEventSerializer
 
     /// <inheritdoc/>
     protected override Task<IEventEnvelope<T>?> DeserializeToEnvelopeAsync<T>(Stream stream,
-                                                                              ContentType? contentType,
+                                                                              DeserializationContext context,
                                                                               CancellationToken cancellationToken = default)
     {
         var serializer = new XmlSerializer(typeof(XmlEventEnvelope<T>));

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -158,6 +158,7 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
     /// <param name="contentType">The type of content contained in the <paramref name="body"/>.</param>
     /// <param name="registration">The bus registration for this event.</param>
     /// <param name="identifier">Identifier given by the transport for the event to be deserialized.</param>
+    /// <param name="raw">The raw data provided by the transport without any manipulation.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     protected async Task<EventContext<TEvent>> DeserializeAsync<TEvent>(IServiceScope scope,
@@ -165,12 +166,14 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
                                                                         ContentType? contentType,
                                                                         EventRegistration registration,
                                                                         string? identifier,
+                                                                        object? raw,
                                                                         CancellationToken cancellationToken = default)
         where TEvent : class
     {
         var ctx = new DeserializationContext(scope.ServiceProvider, body, registration, identifier)
         {
             ContentType = contentType,
+            RawTransportData = raw,
         };
         return await DeserializeAsync<TEvent>(ctx, cancellationToken);
     }


### PR DESCRIPTION
This PR adds support for sending the raw data received from the transport into the `DeserializationContext` so that it is available to the serializer in case more checks need to be done. Further, the `DeserializerToEnvelope<T>(...)` method now takes `DeserializationContext` instead of `ContentType` so that more information is available downstream.