### PR TITLE
Azure Event Hubs configurable checkpoint frequency

### DIFF
--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsPostConfigureOptions.cs
@@ -27,6 +27,9 @@ internal class AzureEventHubsPostConfigureOptions : AzureTransportPostConfigureO
             throw new InvalidOperationException($"'{nameof(AzureEventHubsTransportCredentials.FullyQualifiedNamespace)}' must be provided when using '{nameof(AzureEventHubsTransportCredentials)}'.");
         }
 
+        // ensure the checkpoint interval is not less than 1
+        options.CheckpointInterval = Math.Max(options.CheckpointInterval, 1);
+
         // If there are consumers for this transport, we must check azure blob storage
         var registrations = busOptions.GetRegistrations(TransportNames.AzureEventHubs);
         if (registrations.Any(r => r.Consumers.Count > 0))

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -433,7 +433,8 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
          * Update the checkpoint store if needed so that the app receives
          * only newer events the next time it's run.
         */
-        if (ShouldCheckpoint(successful, ecr.UnhandledErrorBehaviour))
+        if ((data.SequenceNumber % TransportOptions.CheckpointInterval) == 0
+            && ShouldCheckpoint(successful, ecr.UnhandledErrorBehaviour))
         {
             Logger.Checkpointing(partition: args.Partition,
                                  eventHubName: processor.EventHubName,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransportOptions.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Consumer;
 using Azure.Messaging.EventHubs.Producer;
+using Tingle.EventBus;
 using Tingle.EventBus.Configuration;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -45,6 +46,24 @@ public class AzureEventHubsTransportOptions : AzureTransportOptions<AzureEventHu
     /// Defaults to <see langword="true"/>.
     /// </summary>
     public bool UseBasicTier { get; set; } = true;
+
+    /// <summary>
+    /// The number of events consumed after which to checkpoint.
+    /// For values other than <c>1</c>, the implementations of
+    /// <see cref="IEventConsumer{T}"/> for Event Hub events must
+    /// handle duplicate detection.
+    /// </summary>
+    /// <remarks>
+    /// The checkpoint is done by writing to Azure Blob Storage.
+    /// This can occasionally be slow compared to the rate at which the consumer
+    /// is capable of consuming messages. A low checkpoint interval may increase
+    /// the costs incured by your Azure Blob Storage account.
+    /// A high performance application will typically set the interval high so
+    /// that checkpoints are done relatively infrequently and be designed to handle
+    /// duplicate messages in the event of failure.
+    /// </remarks>
+    /// <value>Defaults to 1</value>
+    public int CheckpointInterval { get; set; } = 1;
 
     /// <summary>
     /// A function to create the producer options instead of using the default options.


### PR DESCRIPTION
Checkpointing in Azure Event Hubs can be expensive both in terms of cost of the Blob Storage account used and also computational wise. This PR makes it configurable just like the Kafka transport.