### PR TITLE
Logging fixes

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
@@ -90,7 +90,7 @@ public class AmazonKinesisTransport : EventBusTransportBase<AmazonKinesisTranspo
         };
 
         // send the event
-        Logger.SendingToStream(eventId: @event.Id, streamName: streamName, scheduled: scheduled);
+        Logger.SendingToStream(eventBusId: @event.Id, streamName: streamName, scheduled: scheduled);
         var response = await kinesisClient.PutRecordAsync(request, cancellationToken);
         response.EnsureSuccess();
 

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/ILoggerExtensions.cs
@@ -7,8 +7,8 @@ namespace Microsoft.Extensions.Logging;
 /// </summary>
 internal static partial class ILoggerExtensions
 {
-    [LoggerMessage(100, LogLevel.Information, "Sending {EventId} to '{StreamName}'. Scheduled: {Scheduled}.")]
-    public static partial void SendingToStream(this ILogger logger, string? eventId, string streamName, DateTimeOffset? scheduled);
+    [LoggerMessage(100, LogLevel.Information, "Sending {EventBusId} to '{StreamName}'. Scheduled: {Scheduled}.")]
+    public static partial void SendingToStream(this ILogger logger, string? eventBusId, string streamName, DateTimeOffset? scheduled);
 
     [LoggerMessage(101, LogLevel.Information, "Sending {EventsCount} messages to '{StreamName}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
     private static partial void SendingEventsToStream(this ILogger logger, int eventsCount, string streamName, DateTimeOffset? scheduled, string eventIds);

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/ILoggerExtensions.cs
@@ -10,16 +10,16 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(100, LogLevel.Information, "Sending {EventBusId} to '{StreamName}'. Scheduled: {Scheduled}.")]
     public static partial void SendingToStream(this ILogger logger, string? eventBusId, string streamName, DateTimeOffset? scheduled);
 
-    [LoggerMessage(101, LogLevel.Information, "Sending {EventsCount} messages to '{StreamName}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
-    private static partial void SendingEventsToStream(this ILogger logger, int eventsCount, string streamName, DateTimeOffset? scheduled, string eventIds);
+    [LoggerMessage(101, LogLevel.Information, "Sending {EventsCount} messages to '{StreamName}'. Scheduled: {Scheduled}. Events:\r\n- {EventBusIds}")]
+    private static partial void SendingEventsToStream(this ILogger logger, int eventsCount, string streamName, DateTimeOffset? scheduled, string eventBusIds);
 
-    public static void SendingEventsToStream(this ILogger logger, IList<string?> eventIds, string streamName, DateTimeOffset? scheduled)
+    public static void SendingEventsToStream(this ILogger logger, IList<string?> eventBusIds, string streamName, DateTimeOffset? scheduled)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
-        logger.SendingEventsToStream(eventsCount: eventIds.Count,
+        logger.SendingEventsToStream(eventsCount: eventBusIds.Count,
                                      streamName: streamName,
                                      scheduled: scheduled,
-                                     eventIds: string.Join("\r\n- ", eventIds));
+                                     eventBusIds: string.Join("\r\n- ", eventBusIds));
     }
 
     public static void SendingEventsToStream<T>(this ILogger logger, IList<EventContext<T>> events, string entityPath, DateTimeOffset? scheduled = null)

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -118,7 +118,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
             // get the topic arn and send the message
             var topicArn = await GetTopicArnAsync(registration, cancellationToken);
             var request = new PublishRequest(topicArn: topicArn, message: body.ToString()).SetAttributes(@event);
-            Logger.SendingToTopic(eventId: @event.Id, topicArn: topicArn, scheduled: scheduled);
+            Logger.SendingToTopic(eventBusId: @event.Id, topicArn: topicArn, scheduled: scheduled);
             var response = await snsClient.PublishAsync(request: request, cancellationToken: cancellationToken);
             response.EnsureSuccess();
             sequenceNumber = response.SequenceNumber;
@@ -137,7 +137,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
                 // cap the delay to 900 seconds (15min) which is the max supported by SQS
                 if (delay > 900)
                 {
-                    Logger.DelayCapped(eventId: @event.Id, scheduled: scheduled);
+                    Logger.DelayCapped(eventBusId: @event.Id, scheduled: scheduled);
                     delay = 900;
                 }
 
@@ -148,7 +148,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
             }
 
             // send the message
-            Logger.SendingToQueue(eventId: @event.Id, queueUrl: queueUrl, scheduled: scheduled);
+            Logger.SendingToQueue(eventBusId: @event.Id, queueUrl: queueUrl, scheduled: scheduled);
             var response = await sqsClient.SendMessageAsync(request: request, cancellationToken: cancellationToken);
             response.EnsureSuccess();
             sequenceNumber = response.SequenceNumber;
@@ -190,7 +190,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
                 // get the topic arn and send the message
                 var topicArn = await GetTopicArnAsync(registration, cancellationToken);
                 var request = new PublishRequest(topicArn: topicArn, message: body.ToString()).SetAttributes(@event);
-                Logger.SendingToTopic(eventId: @event.Id, topicArn: topicArn, scheduled: scheduled);
+                Logger.SendingToTopic(eventBusId: @event.Id, topicArn: topicArn, scheduled: scheduled);
                 var response = await snsClient.PublishAsync(request: request, cancellationToken: cancellationToken);
                 response.EnsureSuccess();
 
@@ -219,7 +219,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
                     // cap the delay to 900 seconds (15min) which is the max supported by SQS
                     if (delay > 900)
                     {
-                        Logger.DelayCapped(eventId: @event.Id, scheduled: scheduled);
+                        Logger.DelayCapped(eventBusId: @event.Id, scheduled: scheduled);
                         delay = 900;
                     }
 
@@ -473,7 +473,7 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
                                                      raw: message,
                                                      cancellationToken: cancellationToken);
 
-        Logger.ReceivedMessage(messageId: messageId, eventId: context.Id, queueUrl: queueUrl);
+        Logger.ReceivedMessage(messageId: messageId, eventBusId: context.Id, queueUrl: queueUrl);
 
         var (successful, _) = await ConsumeAsync<TEvent, TConsumer>(ecr: ecr,
                                                                     @event: context,

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/ILoggerExtensions.cs
@@ -12,14 +12,14 @@ internal static partial class ILoggerExtensions
     public static partial void BatchingNotSupported(this ILogger logger);
 
 
-    [LoggerMessage(200, LogLevel.Information, "Sending {EventId} to '{TopicArn}'. Scheduled: {Scheduled}.")]
-    public static partial void SendingToTopic(this ILogger logger, string? eventId, string topicArn, DateTimeOffset? scheduled);
+    [LoggerMessage(200, LogLevel.Information, "Sending {EventBusId} to '{TopicArn}'. Scheduled: {Scheduled}.")]
+    public static partial void SendingToTopic(this ILogger logger, string? eventBusId, string topicArn, DateTimeOffset? scheduled);
 
-    [LoggerMessage(201, LogLevel.Information, "Sending {EventId} to '{QueueUrl}'. Scheduled: {Scheduled}.")]
-    public static partial void SendingToQueue(this ILogger logger, string? eventId, string queueUrl, DateTimeOffset? scheduled);
+    [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{QueueUrl}'. Scheduled: {Scheduled}.")]
+    public static partial void SendingToQueue(this ILogger logger, string? eventBusId, string queueUrl, DateTimeOffset? scheduled);
 
-    [LoggerMessage(202, LogLevel.Warning, "Delay for {EventId} capped at 15min. Scheduled: {Scheduled}.")]
-    public static partial void DelayCapped(this ILogger logger, string? eventId, DateTimeOffset? scheduled);
+    [LoggerMessage(202, LogLevel.Warning, "Delay for {EventBusId} capped at 15min. Scheduled: {Scheduled}.")]
+    public static partial void DelayCapped(this ILogger logger, string? eventBusId, DateTimeOffset? scheduled);
 
 
     [LoggerMessage(300, LogLevel.Trace, "No messages on '{QueueUrl}', delaying check for {Delay}.")]
@@ -28,8 +28,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(301, LogLevel.Debug, "Received {MessagesCount} messages on '{QueueUrl}'")]
     public static partial void ReceivedMessages(this ILogger logger, int messagesCount, string queueUrl);
 
-    [LoggerMessage(302, LogLevel.Information, "Received message: '{MessageId}' containing Event '{EventId}' from '{QueueUrl}'")]
-    public static partial void ReceivedMessage(this ILogger logger, string messageId, string? eventId, string queueUrl);
+    [LoggerMessage(302, LogLevel.Information, "Received message: '{MessageId}' containing Event '{EventBusId}' from '{QueueUrl}'")]
+    public static partial void ReceivedMessage(this ILogger logger, string messageId, string? eventBusId, string queueUrl);
 
     [LoggerMessage(303, LogLevel.Debug, "Processing '{MessageId}' from '{QueueUrl}'")]
     public static partial void ProcessingMessage(this ILogger logger, string messageId, string queueUrl);

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -146,7 +146,7 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
 
         // get the producer and send the event accordingly
         var producer = await GetProducerAsync(reg: registration, deadletter: false, cancellationToken: cancellationToken);
-        Logger.SendingEvent(eventId: @event.Id, eventHubName: producer.EventHubName, scheduled: scheduled);
+        Logger.SendingEvent(eventBusId: @event.Id, eventHubName: producer.EventHubName, scheduled: scheduled);
         await producer.SendAsync(new[] { data }, cancellationToken);
 
         // return the sequence number
@@ -406,7 +406,7 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
                                                      identifier: data.SequenceNumber.ToString(),
                                                      raw: data,
                                                      cancellationToken: cancellationToken);
-        Logger.ReceivedEvent(eventId: context.Id,
+        Logger.ReceivedEvent(eventBusId: context.Id,
                              eventHubName: processor.EventHubName,
                              consumerGroup: processor.ConsumerGroup,
                              partitionKey: data.PartitionKey,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
@@ -37,16 +37,16 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(202, LogLevel.Information, "Sending {EventBusId} to '{EventHubName}'. Scheduled: {Scheduled}")]
     public static partial void SendingEvent(this ILogger logger, string? eventBusId, string eventHubName, DateTimeOffset? scheduled);
 
-    [LoggerMessage(203, LogLevel.Information, "Sending {EventsCount} events to '{EventHubName}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
-    private static partial void SendingEvents(this ILogger logger, int eventsCount, string eventHubName, DateTimeOffset? scheduled, string eventIds);
+    [LoggerMessage(203, LogLevel.Information, "Sending {EventsCount} events to '{EventHubName}'. Scheduled: {Scheduled}. Events:\r\n- {EventBusIds}")]
+    private static partial void SendingEvents(this ILogger logger, int eventsCount, string eventHubName, DateTimeOffset? scheduled, string eventBusIds);
 
-    public static void SendingEvents(this ILogger logger, IList<string?> eventIds, string eventHubName, DateTimeOffset? scheduled)
+    public static void SendingEvents(this ILogger logger, IList<string?> eventBusIds, string eventHubName, DateTimeOffset? scheduled)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
-        logger.SendingEvents(eventsCount: eventIds.Count,
+        logger.SendingEvents(eventsCount: eventBusIds.Count,
                              eventHubName: eventHubName,
                              scheduled: scheduled,
-                             eventIds: string.Join("\r\n- ", eventIds));
+                             eventBusIds: string.Join("\r\n- ", eventBusIds));
     }
 
     public static void SendingEvents<T>(this ILogger logger, IList<EventContext<T>> events, string eventHubName, DateTimeOffset? scheduled = null)

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
@@ -34,8 +34,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(201, LogLevel.Warning, "Azure EventHubs does not support expiring events.")]
     public static partial void ExpiryNotSupported(this ILogger logger);
 
-    [LoggerMessage(202, LogLevel.Information, "Sending {EventId} to '{EventHubName}'. Scheduled: {Scheduled}")]
-    public static partial void SendingEvent(this ILogger logger, string? eventId, string eventHubName, DateTimeOffset? scheduled);
+    [LoggerMessage(202, LogLevel.Information, "Sending {EventBusId} to '{EventHubName}'. Scheduled: {Scheduled}")]
+    public static partial void SendingEvent(this ILogger logger, string? eventBusId, string eventHubName, DateTimeOffset? scheduled);
 
     [LoggerMessage(203, LogLevel.Information, "Sending {EventsCount} events to '{EventHubName}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
     private static partial void SendingEvents(this ILogger logger, int eventsCount, string eventHubName, DateTimeOffset? scheduled, string eventIds);
@@ -66,6 +66,6 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EventHubName}/{ConsumerGroup}'.\r\nPartitionKey: {PartitionKey}\r\nSequenceNumber: {SequenceNumber}'")]
     public static partial void ProcessingEvent(this ILogger logger, string messageId, string eventHubName, string consumerGroup, string partitionKey, long sequenceNumber);
 
-    [LoggerMessage(302, LogLevel.Information, "Received event: '{EventId}' from '{EventHubName}/{ConsumerGroup}'.\r\nPartitionKey: {PartitionKey}\r\nSequenceNumber: {SequenceNumber}'")]
-    public static partial void ReceivedEvent(this ILogger logger, string? eventId, string eventHubName, string consumerGroup, string partitionKey, long sequenceNumber);
+    [LoggerMessage(302, LogLevel.Information, "Received event: '{EventBusId}' from '{EventHubName}/{ConsumerGroup}'.\r\nPartitionKey: {PartitionKey}\r\nSequenceNumber: {SequenceNumber}'")]
+    public static partial void ReceivedEvent(this ILogger logger, string? eventBusId, string eventHubName, string consumerGroup, string partitionKey, long sequenceNumber);
 }

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -99,7 +99,7 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
 
         // get the queue client and send the message
         var queueClient = await GetQueueClientAsync(reg: registration, deadletter: false, cancellationToken: cancellationToken);
-        Logger.SendingMessage(eventId: @event.Id, queueName: queueClient.Name, scheduled: scheduled);
+        Logger.SendingMessage(eventBusId: @event.Id, queueName: queueClient.Name, scheduled: scheduled);
         var response = await queueClient.SendMessageAsync(messageText: body.ToString(),
                                                           visibilityTimeout: visibilityTimeout,
                                                           timeToLive: ttl,
@@ -138,7 +138,7 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
             var ttl = @event.Expires - DateTimeOffset.UtcNow;
 
             // send the message
-            Logger.SendingMessage(eventId: @event.Id, queueName: queueClient.Name, scheduled: scheduled);
+            Logger.SendingMessage(eventBusId: @event.Id, queueName: queueClient.Name, scheduled: scheduled);
             var response = await queueClient.SendMessageAsync(messageText: body.ToString(),
                                                               visibilityTimeout: visibilityTimeout,
                                                               timeToLive: ttl,
@@ -336,7 +336,7 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
                                                      raw: message,
                                                      cancellationToken: cancellationToken);
 
-        Logger.ReceivedMessage(messageId: messageId, eventId: context.Id, queueName: queueClient.Name);
+        Logger.ReceivedMessage(messageId: messageId, eventBusId: context.Id, queueName: queueClient.Name);
 
         // if the event contains the parent activity id, set it
         if (context.Headers.TryGetValue(HeaderNames.ActivityId, out var parentActivityId))

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/ILoggerExtensions.cs
@@ -15,8 +15,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(200, LogLevel.Warning, "Azure Queue Storage does not support batching. The events will be looped through one by one.")]
     public static partial void BatchingNotSupported(this ILogger logger);
 
-    [LoggerMessage(201, LogLevel.Information, "Sending {EventId} to '{QueueName}'. Scheduled: {Scheduled}.")]
-    public static partial void SendingMessage(this ILogger logger, string? eventId, string queueName, DateTimeOffset? scheduled);
+    [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{QueueName}'. Scheduled: {Scheduled}.")]
+    public static partial void SendingMessage(this ILogger logger, string? eventBusId, string queueName, DateTimeOffset? scheduled);
 
     [LoggerMessage(202, LogLevel.Information, "Cancelling '{MessageId}|{PopReceipt}' on '{QueueName}'.")]
     public static partial void CancelingMessage(this ILogger logger, string messageId, string popReceipt, string queueName);
@@ -31,8 +31,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(302, LogLevel.Debug, "Processing '{MessageId}' from '{QueueName}'")]
     public static partial void ProcessingMessage(this ILogger logger, string messageId, string queueName);
 
-    [LoggerMessage(303, LogLevel.Information, "Received message: '{MessageId}' containing Event '{EventId}' from '{QueueName}'")]
-    public static partial void ReceivedMessage(this ILogger logger, string messageId, string? eventId, string queueName);
+    [LoggerMessage(303, LogLevel.Information, "Received message: '{MessageId}' containing Event '{EventBusId}' from '{QueueName}'")]
+    public static partial void ReceivedMessage(this ILogger logger, string messageId, string? eventBusId, string queueName);
 
     [LoggerMessage(304, LogLevel.Trace, "Deleting '{MessageId}' on '{QueueName}'")]
     public static partial void DeletingMessage(this ILogger logger, string messageId, string queueName);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -155,7 +155,7 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
 
         // Get the sender and send the message accordingly
         var sender = await GetSenderAsync(registration, cancellationToken);
-        Logger.SendingMessage(eventId: @event.Id, entityPath: sender.EntityPath, scheduled: scheduled);
+        Logger.SendingMessage(eventBusId: @event.Id, entityPath: sender.EntityPath, scheduled: scheduled);
         if (scheduled != null)
         {
             var seqNum = await sender.ScheduleMessageAsync(message: message,
@@ -538,7 +538,7 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
                                                      raw: message,
                                                      cancellationToken: cancellationToken);
 
-        Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventId: context.Id, entityPath: entityPath);
+        Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventBusId: context.Id, entityPath: entityPath);
 
         // set the extras
         context.SetServiceBusReceivedMessage(message);
@@ -550,7 +550,7 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
 
         // Decide the action to execute then execute
         var action = DecideAction(successful, ecr.UnhandledErrorBehaviour, processor.AutoCompleteMessages);
-        Logger.PostConsumeAction(action: action, messageId: messageId, entityPath: entityPath, eventId: context.Id);
+        Logger.PostConsumeAction(action: action, messageId: messageId, entityPath: entityPath, eventBusId: context.Id);
 
         if (action == PostConsumeAction.Complete)
         {

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
@@ -71,8 +71,8 @@ internal static partial class ILoggerExtensions
 
 
 
-    [LoggerMessage(201, LogLevel.Information, "Sending {EventId} to '{EntityPath}'. Scheduled: {Scheduled}")]
-    public static partial void SendingMessage(this ILogger logger, string? eventId, string entityPath, DateTimeOffset? scheduled);
+    [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{EntityPath}'. Scheduled: {Scheduled}")]
+    public static partial void SendingMessage(this ILogger logger, string? eventBusId, string entityPath, DateTimeOffset? scheduled);
 
     [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
     private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventIds);
@@ -108,14 +108,14 @@ internal static partial class ILoggerExtensions
     }
 
 
-    [LoggerMessage(300, LogLevel.Information, "Received message: '{SequenceNumber}' containing Event '{EventId}' from '{EntityPath}'")]
-    public static partial void ReceivedMessage(this ILogger logger, long sequenceNumber, string? eventId, string entityPath);
+    [LoggerMessage(300, LogLevel.Information, "Received message: '{SequenceNumber}' containing Event '{EventBusId}' from '{EntityPath}'")]
+    public static partial void ReceivedMessage(this ILogger logger, long sequenceNumber, string? eventBusId, string entityPath);
 
     [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EntityPath}'")]
     public static partial void ProcessingMessage(this ILogger logger, string? messageId, string entityPath);
 
-    [LoggerMessage(302, LogLevel.Debug, "Post Consume action: {Action} for message: {MessageId} from '{EntityPath}' containing Event: {EventId}.")]
-    public static partial void PostConsumeAction(this ILogger logger, PostConsumeAction? action, string? messageId, string entityPath, string? eventId);
+    [LoggerMessage(302, LogLevel.Debug, "Post Consume action: {Action} for message: {MessageId} from '{EntityPath}' containing Event: {EventBusId}.")]
+    public static partial void PostConsumeAction(this ILogger logger, PostConsumeAction? action, string? messageId, string entityPath, string? eventBusId);
 
     [LoggerMessage(303, LogLevel.Debug, "Message receiving faulted. Namespace: {FullyQualifiedNamespace}, Entity Path: {EntityPath}, Source: {ErrorSource}")]
     public static partial void MessageReceivingFaulted(this ILogger logger, string fullyQualifiedNamespace, string entityPath, ServiceBusErrorSource errorSource, Exception ex);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
@@ -74,16 +74,16 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{EntityPath}'. Scheduled: {Scheduled}")]
     public static partial void SendingMessage(this ILogger logger, string? eventBusId, string entityPath, DateTimeOffset? scheduled);
 
-    [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
-    private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventIds);
+    [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventBusIds}")]
+    private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventBusIds);
 
-    public static void SendingMessages(this ILogger logger, IList<string?> eventIds, string entityPath, DateTimeOffset? scheduled)
+    public static void SendingMessages(this ILogger logger, IList<string?> eventBusIds, string entityPath, DateTimeOffset? scheduled)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
-        logger.SendingMessages(eventsCount: eventIds.Count,
+        logger.SendingMessages(eventsCount: eventBusIds.Count,
                                entityPath: entityPath,
                                scheduled: scheduled,
-                               eventIds: string.Join("\r\n- ", eventIds));
+                               eventBusIds: string.Join("\r\n- ", eventBusIds));
     }
 
     public static void SendingMessages<T>(this ILogger logger, IList<EventContext<T>> events, string entityPath, DateTimeOffset? scheduled = null)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/ILoggerExtensions.cs
@@ -114,7 +114,7 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EntityPath}'")]
     public static partial void ProcessingMessage(this ILogger logger, string? messageId, string entityPath);
 
-    [LoggerMessage(302, LogLevel.Debug, "Post Consume action: {Action} for message: {MessageId} from '{EntityPath}' containing Event: {EventBusId}.")]
+    [LoggerMessage(302, LogLevel.Debug, "Post Consume action: {Action} for message: {MessageId} from '{EntityPath}' containing Event: '{EventBusId}'.")]
     public static partial void PostConsumeAction(this ILogger logger, PostConsumeAction? action, string? messageId, string entityPath, string? eventBusId);
 
     [LoggerMessage(303, LogLevel.Debug, "Message receiving faulted. Namespace: {FullyQualifiedNamespace}, Entity Path: {EntityPath}, Source: {ErrorSource}")]

--- a/src/Tingle.EventBus.Transports.InMemory/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/ILoggerExtensions.cs
@@ -29,8 +29,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(200, LogLevel.Warning, "InMemory EventBus uses a short-lived timer that is not persisted for scheduled publish.")]
     public static partial void SchedulingShortLived(this ILogger logger);
 
-    [LoggerMessage(201, LogLevel.Information, "Sending {EventId} to '{EntityPath}'. Scheduled: {Scheduled}")]
-    public static partial void SendingMessage(this ILogger logger, string? eventId, string entityPath, DateTimeOffset? scheduled);
+    [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{EntityPath}'. Scheduled: {Scheduled}")]
+    public static partial void SendingMessage(this ILogger logger, string? eventBusId, string entityPath, DateTimeOffset? scheduled);
 
     [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
     private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventIds);
@@ -66,8 +66,8 @@ internal static partial class ILoggerExtensions
     }
 
 
-    [LoggerMessage(300, LogLevel.Information, "Received message: '{SequenceNumber}' containing Event '{EventId}' from '{EntityPath}'")]
-    public static partial void ReceivedMessage(this ILogger logger, long sequenceNumber, string? eventId, string entityPath);
+    [LoggerMessage(300, LogLevel.Information, "Received message: '{SequenceNumber}' containing Event '{EventBusId}' from '{EntityPath}'")]
+    public static partial void ReceivedMessage(this ILogger logger, long sequenceNumber, string? eventBusId, string entityPath);
 
     [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EntityPath}'")]
     public static partial void ProcessingMessage(this ILogger logger, string? messageId, string entityPath);

--- a/src/Tingle.EventBus.Transports.InMemory/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/ILoggerExtensions.cs
@@ -32,16 +32,16 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(201, LogLevel.Information, "Sending {EventBusId} to '{EntityPath}'. Scheduled: {Scheduled}")]
     public static partial void SendingMessage(this ILogger logger, string? eventBusId, string entityPath, DateTimeOffset? scheduled);
 
-    [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventIds}")]
-    private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventIds);
+    [LoggerMessage(202, LogLevel.Information, "Sending {EventsCount} messages to '{EntityPath}'. Scheduled: {Scheduled}. Events:\r\n- {EventBusIds}")]
+    private static partial void SendingMessages(this ILogger logger, int eventsCount, string entityPath, DateTimeOffset? scheduled, string eventBusIds);
 
-    public static void SendingMessages(this ILogger logger, IList<string?> eventIds, string entityPath, DateTimeOffset? scheduled)
+    public static void SendingMessages(this ILogger logger, IList<string?> eventBusIds, string entityPath, DateTimeOffset? scheduled)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
-        logger.SendingMessages(eventsCount: eventIds.Count,
+        logger.SendingMessages(eventsCount: eventBusIds.Count,
                                entityPath: entityPath,
                                scheduled: scheduled,
-                               eventIds: string.Join("\r\n- ", eventIds));
+                               eventBusIds: string.Join("\r\n- ", eventBusIds));
     }
 
     public static void SendingMessages<T>(this ILogger logger, IList<EventContext<T>> events, string entityPath, DateTimeOffset? scheduled = null)

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -154,7 +154,7 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
 
         // Get the queue and send the message accordingly
         var sender = await GetSenderAsync(registration, cancellationToken);
-        Logger.SendingMessage(eventId: @event.Id, entityPath: sender.EntityPath, scheduled: scheduled);
+        Logger.SendingMessage(eventBusId: @event.Id, entityPath: sender.EntityPath, scheduled: scheduled);
         if (scheduled != null)
         {
             var seqNum = await sender.ScheduleMessageAsync(message: message, cancellationToken: cancellationToken);
@@ -377,7 +377,7 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
                                                      raw: message,
                                                      cancellationToken: cancellationToken);
 
-        Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventId: context.Id, entityPath: entityPath);
+        Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventBusId: context.Id, entityPath: entityPath);
 
         // set the extras
         context.SetInMemoryReceivedMessage(message);

--- a/src/Tingle.EventBus.Transports.Kafka/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/ILoggerExtensions.cs
@@ -22,6 +22,6 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(104, LogLevel.Debug, "Processing '{MessageKey}")]
     public static partial void ProcessingMessage(this ILogger logger, string messageKey);
 
-    [LoggerMessage(105, LogLevel.Information, "Received event: '{MessageKey}' containing Event '{EventId}'")]
-    public static partial void ReceivedEvent(this ILogger logger, string messageKey, string? eventId);
+    [LoggerMessage(105, LogLevel.Information, "Received event: '{MessageKey}' containing Event '{EventBusId}'")]
+    public static partial void ReceivedEvent(this ILogger logger, string messageKey, string? eventBusId);
 }

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -329,7 +329,7 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
 
         // Decide the action to execute then execute
         var action = DecideAction(successful, ecr.UnhandledErrorBehaviour);
-        Logger.LogDebug("Post Consume action: {Action} for message: {MessageId} containing Event: {EventBusId}.",
+        Logger.LogDebug("Post Consume action: {Action} for message: {MessageId} containing Event: '{EventBusId}'.",
                         action,
                         messageId,
                         context.Id);

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -329,7 +329,7 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
 
         // Decide the action to execute then execute
         var action = DecideAction(successful, ecr.UnhandledErrorBehaviour);
-        Logger.LogDebug("Post Consume action: {Action} for message: {MessageId} containing Event: {EventId}.",
+        Logger.LogDebug("Post Consume action: {Action} for message: {MessageId} containing Event: {EventBusId}.",
                         action,
                         messageId,
                         context.Id);

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -90,7 +90,7 @@ public class EventBus : IHostedService
         activity?.AddTag(ActivityTagNames.MessagingConversationId, @event.CorrelationId);
 
         // Publish on the transport
-        logger.SendingEvent(eventId: @event.Id, transportName: transport.Name, scheduled: scheduled);
+        logger.SendingEvent(eventBusId: @event.Id, transportName: transport.Name, scheduled: scheduled);
         return await transport.PublishAsync(@event: @event,
                                             registration: reg,
                                             scheduled: scheduled,

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -42,23 +42,23 @@ internal static partial class ILoggerExtensions
 
     #region Events (300 series)
 
-    [LoggerMessage(301, LogLevel.Information, "Sending event '{EventId}' using '{TransportName}' transport.")]
-    private static partial void SendingEvent(this ILogger logger, string? eventId, string transportName);
+    [LoggerMessage(301, LogLevel.Information, "Sending event '{EventBusId}' using '{TransportName}' transport.")]
+    private static partial void SendingEvent(this ILogger logger, string? eventBusId, string transportName);
 
-    [LoggerMessage(302, LogLevel.Information, "Sending event '{EventId}' using '{TransportName}' transport. Scheduled: {Scheduled:o}, Delay: {ReadableDelay} ({RetryDelay})")]
-    private static partial void SendingScheduledEvent(this ILogger logger, string? eventId, string transportName, DateTimeOffset scheduled, string readableDelay, TimeSpan retryDelay);
+    [LoggerMessage(302, LogLevel.Information, "Sending event '{EventBusId}' using '{TransportName}' transport. Scheduled: {Scheduled:o}, Delay: {ReadableDelay} ({RetryDelay})")]
+    private static partial void SendingScheduledEvent(this ILogger logger, string? eventBusId, string transportName, DateTimeOffset scheduled, string readableDelay, TimeSpan retryDelay);
 
-    public static void SendingEvent(this ILogger logger, string? eventId, string transportName, DateTimeOffset? scheduled)
+    public static void SendingEvent(this ILogger logger, string? eventBusId, string transportName, DateTimeOffset? scheduled)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
         if (scheduled == null)
         {
-            logger.SendingEvent(eventId, transportName);
+            logger.SendingEvent(eventBusId, transportName);
         }
         else
         {
             var (readableDelay, delay) = GetDelay(scheduled.Value);
-            logger.SendingScheduledEvent(eventId, transportName, scheduled.Value, readableDelay, delay);
+            logger.SendingScheduledEvent(eventBusId, transportName, scheduled.Value, readableDelay, delay);
         }
     }
 
@@ -89,15 +89,15 @@ internal static partial class ILoggerExtensions
         logger.SendingEvents(events.Select(e => e.Id).ToList(), transportName, scheduled);
     }
 
-    [LoggerMessage(305, LogLevel.Information, "Canceling event '{EventId}' on '{TransportName}' transport")]
-    public static partial void CancelingEvent(this ILogger logger, string eventId, string transportName);
+    [LoggerMessage(305, LogLevel.Information, "Canceling event '{EventBusId}' on '{TransportName}' transport")]
+    public static partial void CancelingEvent(this ILogger logger, string eventBusId, string transportName);
 
     [LoggerMessage(306, LogLevel.Information, "Canceling {EventsCount} events on '{TransportName}' transport.\r\nEvents: {EventIds}")]
     public static partial void CancelingEvents(this ILogger logger, int eventsCount, IList<string> eventIds, string transportName);
     public static void CancelingEvents(this ILogger logger, IList<string> eventIds, string transportName) => logger.CancelingEvents(eventIds.Count, eventIds, transportName);
 
-    [LoggerMessage(307, LogLevel.Error, "Event processing failed. {Action} (EventId: {EventId})")]
-    public static partial void ConsumeFailed(this ILogger logger, string action, string? eventId, Exception ex);
+    [LoggerMessage(307, LogLevel.Error, "Event processing failed. {Action} (EventId: {EventBusId})")]
+    public static partial void ConsumeFailed(this ILogger logger, string action, string? eventBusId, Exception ex);
 
     public static void ConsumeFailed(this ILogger logger, UnhandledConsumerErrorBehaviour? behaviour, string? eventId, Exception ex)
     {
@@ -137,8 +137,8 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(501, LogLevel.Warning, "Deserialization resulted in a null which should not happen. Identifier: '{Identifier}', Type: '{EventType}'.")]
     public static partial void DeserializationResultedInNull(this ILogger logger, string? identifier, string? eventType);
 
-    [LoggerMessage(502, LogLevel.Warning, "Deserialized event should not have a null event. Identifier: '{Identifier}', EventId: '{EventId}', Type: '{EventType}'.")]
-    public static partial void DeserializedEventShouldNotBeNull(this ILogger logger, string? identifier, string? eventId, string? eventType);
+    [LoggerMessage(502, LogLevel.Warning, "Deserialized event should not have a null event. Identifier: '{Identifier}', EventId: '{EventBusId}', Type: '{EventType}'.")]
+    public static partial void DeserializedEventShouldNotBeNull(this ILogger logger, string? identifier, string? eventBusId, string? eventType);
 
     #endregion
 }

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -99,7 +99,7 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(307, LogLevel.Error, "Event processing failed. {Action} (EventId: {EventBusId})")]
     public static partial void ConsumeFailed(this ILogger logger, string action, string? eventBusId, Exception ex);
 
-    public static void ConsumeFailed(this ILogger logger, UnhandledConsumerErrorBehaviour? behaviour, string? eventId, Exception ex)
+    public static void ConsumeFailed(this ILogger logger, UnhandledConsumerErrorBehaviour? behaviour, string? eventBusId, Exception ex)
     {
         var action = behaviour switch
         {
@@ -108,7 +108,7 @@ internal static partial class ILoggerExtensions
             _ => "Transport specific handling in play.",
         };
 
-        logger.ConsumeFailed(action, eventId, ex);
+        logger.ConsumeFailed(action, eventBusId, ex);
     }
 
     private static (string readableDelay, TimeSpan delay) GetDelay(DateTimeOffset scheduled)

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -62,23 +62,23 @@ internal static partial class ILoggerExtensions
         }
     }
 
-    [LoggerMessage(303, LogLevel.Information, "Sending {EventsCount} events using '{TransportName}' transport.\r\nEvents: {EventIds}")]
-    private static partial void SendingEvents(this ILogger logger, int eventsCount, string transportName, IList<string?> eventIds);
+    [LoggerMessage(303, LogLevel.Information, "Sending {EventsCount} events using '{TransportName}' transport.\r\nEvents: {EventBusIds}")]
+    private static partial void SendingEvents(this ILogger logger, int eventsCount, string transportName, IList<string?> eventBusIds);
 
-    [LoggerMessage(304, LogLevel.Information, "Sending {EventsCount} events using '{TransportName}' transport. Scheduled: {Scheduled:o}, Delay: {ReadableDelay} ({RetryDelay}).\r\nEvents: {EventIds}")]
-    private static partial void SendingScheduledEvents(this ILogger logger, int eventsCount, string transportName, DateTimeOffset scheduled, string readableDelay, TimeSpan retryDelay, IList<string?> eventIds);
+    [LoggerMessage(304, LogLevel.Information, "Sending {EventsCount} events using '{TransportName}' transport. Scheduled: {Scheduled:o}, Delay: {ReadableDelay} ({RetryDelay}).\r\nEvents: {EventBusIds}")]
+    private static partial void SendingScheduledEvents(this ILogger logger, int eventsCount, string transportName, DateTimeOffset scheduled, string readableDelay, TimeSpan retryDelay, IList<string?> eventBusIds);
 
-    public static void SendingEvents(this ILogger logger, IList<string?> eventIds, string transportName, DateTimeOffset? scheduled = null)
+    public static void SendingEvents(this ILogger logger, IList<string?> eventBusIds, string transportName, DateTimeOffset? scheduled = null)
     {
         if (!logger.IsEnabled(LogLevel.Information)) return;
         if (scheduled == null)
         {
-            logger.SendingEvents(eventsCount: eventIds.Count, transportName: transportName, eventIds: eventIds);
+            logger.SendingEvents(eventsCount: eventBusIds.Count, transportName: transportName, eventBusIds: eventBusIds);
         }
         else
         {
             var (readableDelay, delay) = GetDelay(scheduled.Value);
-            logger.SendingScheduledEvents(eventIds.Count, transportName, scheduled.Value, readableDelay, delay, eventIds);
+            logger.SendingScheduledEvents(eventBusIds.Count, transportName, scheduled.Value, readableDelay, delay, eventBusIds);
         }
     }
 
@@ -92,9 +92,9 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(305, LogLevel.Information, "Canceling event '{EventBusId}' on '{TransportName}' transport")]
     public static partial void CancelingEvent(this ILogger logger, string eventBusId, string transportName);
 
-    [LoggerMessage(306, LogLevel.Information, "Canceling {EventsCount} events on '{TransportName}' transport.\r\nEvents: {EventIds}")]
-    public static partial void CancelingEvents(this ILogger logger, int eventsCount, IList<string> eventIds, string transportName);
-    public static void CancelingEvents(this ILogger logger, IList<string> eventIds, string transportName) => logger.CancelingEvents(eventIds.Count, eventIds, transportName);
+    [LoggerMessage(306, LogLevel.Information, "Canceling {EventsCount} events on '{TransportName}' transport.\r\nEvents: {EventBusIds}")]
+    public static partial void CancelingEvents(this ILogger logger, int eventsCount, IList<string> eventBusIds, string transportName);
+    public static void CancelingEvents(this ILogger logger, IList<string> eventBusIds, string transportName) => logger.CancelingEvents(eventBusIds.Count, eventBusIds, transportName);
 
     [LoggerMessage(307, LogLevel.Error, "Event processing failed. {Action} (EventId: {EventBusId})")]
     public static partial void ConsumeFailed(this ILogger logger, string action, string? eventBusId, Exception ex);

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -69,7 +69,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
         if (envelope.Event is null)
         {
             Logger.DeserializedEventShouldNotBeNull(identifier: context.Identifier,
-                                                    eventId: envelope.Id,
+                                                    eventBusId: envelope.Id,
                                                     eventType: context.Registration.EventType.FullName);
             return null;
         }


### PR DESCRIPTION
When using `EventId` as a replaceable parameter in logging templates, it gets replaced by a value of `Microsoft.Extensions.Logging.EventId` which isn't the desired behavior. This PR fixes that by renaming the parameter to `EventBusId` or `EventBusIds`.