### PR TITLE
Startup changes for more production scenarios

### DIFF
--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -15,7 +15,6 @@ public class EventBusOptions
 {
     /// <summary>
     /// The duration of time to delay the starting of the bus.
-    /// Max value is 10 minutes and minimum is 5 seconds.
     /// When <see langword="null"/>, the bus is started immediately.
     /// </summary>
     public TimeSpan? StartupDelay { get; set; }

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -15,10 +15,10 @@ public class EventBusOptions
 {
     /// <summary>
     /// The duration of time to delay the starting of the bus.
-    /// The default value is 5 seconds. Max value is 10 minutes and minimum is 5 seconds.
+    /// Max value is 10 minutes and minimum is 5 seconds.
     /// When <see langword="null"/>, the bus is started immediately.
     /// </summary>
-    public TimeSpan? StartupDelay { get; set; } = TimeSpan.FromSeconds(5);
+    public TimeSpan? StartupDelay { get; set; }
 
     /// <summary>
     /// Gets the <see cref="EventBusReadinessOptions"/> for the Event Bus.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusPostConfigureOptions.cs
@@ -27,15 +27,6 @@ internal class EventBusPostConfigureOptions : IPostConfigureOptions<EventBusOpti
             options.Readiness.Timeout = TimeSpan.FromTicks(ticks);
         }
 
-        // Check bounds for startup delay, if provided
-        if (options.StartupDelay != null)
-        {
-            ticks = options.StartupDelay.Value.Ticks;
-            ticks = Math.Max(ticks, TimeSpan.FromSeconds(5).Ticks); // must be more than 5 seconds
-            ticks = Math.Min(ticks, TimeSpan.FromMinutes(10).Ticks); // must be less than 10 minutes
-            options.StartupDelay = TimeSpan.FromTicks(ticks);
-        }
-
         // Check bounds for duplicate detection duration, if duplicate detection is enabled
         if (options.EnableDeduplication)
         {

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -240,16 +240,19 @@ public class EventBus : IHostedService
 
     private async Task StartTransportsAsync(CancellationToken cancellationToken)
     {
-        try
+        if (options.Readiness.Enabled)
         {
-            // Perform readiness check before starting bus.
-            logger.StartupReadinessCheck();
-            await readinessProvider.WaitReadyAsync(cancellationToken: cancellationToken);
-        }
-        catch (Exception ex)
-        {
-            logger.StartupReadinessCheckFailed(ex);
-            throw; // re-throw to prevent from getting healthy
+            try
+            {
+                // Perform readiness check before starting bus.
+                logger.StartupReadinessCheck();
+                await readinessProvider.WaitReadyAsync(cancellationToken: cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.StartupReadinessCheckFailed(ex);
+                throw; // re-throw to prevent from getting healthy
+            }
         }
 
         // Start the bus and its transports

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -205,13 +205,14 @@ public class EventBus : IHostedService
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         // If a startup delay has been specified, apply it
-        if (options.StartupDelay != null)
+        var delay = options.StartupDelay;
+        if (delay != null && delay > TimeSpan.Zero)
         {
             // We cannot await the call because it will cause other components not to start.
             // Instead, create a cancellation token linked to the one provided so that we can
             // stop startup if told to do so.
             var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            _ = DelayThenStartTransportsAsync(options.StartupDelay.Value, cts.Token);
+            _ = DelayThenStartTransportsAsync(delay.Value, cts.Token);
         }
         else
         {


### PR DESCRIPTION
This PR fixes the startup of the EventBus to enable more production usage scenarios:
- Readiness check in the EventBus should only be done if enabled.
- Ensure `StartupDelay` is positive before using it in the EventBus.
- Remove limits on `StartupDelay` and it should be `null` by default to allow for really quick starts.