### PR TITLE
Prevent double configuration of options

### DIFF
--- a/samples/CustomEventSerializer/AzureDevOpsEventSerializer.cs
+++ b/samples/CustomEventSerializer/AzureDevOpsEventSerializer.cs
@@ -9,7 +9,7 @@ public class AzureDevOpsEventSerializer : AbstractEventSerializer
 {
     private readonly JsonSerializer serializer = JsonSerializer.CreateDefault();
 
-    public AzureDevOpsEventSerializer(IOptionsMonitor<EventBusOptions> optionsAccessor,
+    public AzureDevOpsEventSerializer(IOptionsMonitor<EventBusSerializationOptions> optionsAccessor,
                                       ILoggerFactory loggerFactory)
         : base(optionsAccessor, loggerFactory) { }
 

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializer.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializer.cs
@@ -21,7 +21,7 @@ public class NewtonsoftJsonSerializer : AbstractEventSerializer
     /// <param name="optionsAccessor"></param>
     /// <param name="loggerFactory"></param>
     public NewtonsoftJsonSerializer(IOptions<NewtonsoftJsonSerializerOptions> serializerOptionsAccessor,
-                                    IOptionsMonitor<EventBusOptions> optionsAccessor,
+                                    IOptionsMonitor<EventBusSerializationOptions> optionsAccessor,
                                     ILoggerFactory loggerFactory)
         : base(optionsAccessor, loggerFactory)
     {

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubEventSerializer.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubEventSerializer.cs
@@ -14,7 +14,7 @@ internal class IotHubEventSerializer : AbstractEventSerializer
     private static readonly Type BaseType = typeof(IotHubEvent<,,>);
     private static readonly ConcurrentDictionary<Type, MappedTypes> typeMaps = new();
 
-    public IotHubEventSerializer(IOptionsMonitor<EventBusOptions> optionsAccessor,
+    public IotHubEventSerializer(IOptionsMonitor<EventBusSerializationOptions> optionsAccessor,
                                  ILoggerFactory loggerFactory)
         : base(optionsAccessor, loggerFactory) { }
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -46,12 +46,32 @@ public class EventBusBuilder
     /// </summary>
     public IServiceCollection Services { get; }
 
-    /// <summary>
-    /// Configure options for EventBus
-    /// </summary>
+    /// <summary>Configure options for the EventBus.</summary>
     /// <param name="configure"></param>
     /// <returns></returns>
     public EventBusBuilder Configure(Action<EventBusOptions> configure)
+    {
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
+
+        Services.Configure(configure);
+        return this;
+    }
+
+    /// <summary>Configure readiness options for the EventBus.</summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public EventBusBuilder ConfigureReadiness(Action<EventBusReadinessOptions> configure)
+    {
+        if (configure is null) throw new ArgumentNullException(nameof(configure));
+
+        Services.Configure(configure);
+        return this;
+    }
+
+    /// <summary>Configure serialization options for the EventBus.</summary>
+    /// <param name="configure"></param>
+    /// <returns></returns>
+    public EventBusBuilder ConfigureSerialization(Action<EventBusSerializationOptions> configure)
     {
         if (configure is null) throw new ArgumentNullException(nameof(configure));
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -20,11 +20,6 @@ public class EventBusOptions
     public TimeSpan? StartupDelay { get; set; }
 
     /// <summary>
-    /// Gets the <see cref="EventBusReadinessOptions"/> for the Event Bus.
-    /// </summary>
-    public EventBusReadinessOptions Readiness { get; } = new EventBusReadinessOptions();
-
-    /// <summary>
     /// Gets the <see cref="EventBusNamingOptions"/> for the Event Bus.
     /// </summary>
     public EventBusNamingOptions Naming { get; } = new EventBusNamingOptions();

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -1,9 +1,7 @@
 ﻿using Polly.Retry;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using Tingle.EventBus;
 using Tingle.EventBus.Configuration;
-using Tingle.EventBus.Serialization;
 using Tingle.EventBus.Transports;
 
 namespace Microsoft.Extensions.DependencyInjection;
@@ -23,28 +21,6 @@ public class EventBusOptions
     /// Gets the <see cref="EventBusNamingOptions"/> for the Event Bus.
     /// </summary>
     public EventBusNamingOptions Naming { get; } = new EventBusNamingOptions();
-
-    /// <summary>
-    /// The options to use for serialization.
-    /// </summary>
-    public JsonSerializerOptions SerializerOptions { get; set; } = new JsonSerializerOptions
-    {
-        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals
-                       | System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
-        WriteIndented = false, // less data used
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault
-                               | System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
-
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true,
-        AllowTrailingCommas = true,
-        ReadCommentHandling = JsonCommentHandling.Skip,
-    };
-
-    /// <summary>
-    /// The information about the host where the EventBus is running.
-    /// </summary>
-    public HostInfo? HostInfo { get; set; }
 
     /// <summary>
     /// Indicates if the messages/events produced require guard against duplicate messages.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusSerializationOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusSerializationOptions.cs
@@ -1,0 +1,32 @@
+﻿using System.Text.Json;
+using Tingle.EventBus.Serialization;
+
+namespace Microsoft.Extensions.DependencyInjection;
+
+/// <summary>
+/// Specified options for serialization.
+/// </summary>
+public class EventBusSerializationOptions
+{
+    /// <summary>
+    /// The options to use for serialization.
+    /// </summary>
+    public JsonSerializerOptions SerializerOptions { get; set; } = new JsonSerializerOptions
+    {
+        NumberHandling = System.Text.Json.Serialization.JsonNumberHandling.AllowNamedFloatingPointLiterals
+                       | System.Text.Json.Serialization.JsonNumberHandling.AllowReadingFromString,
+        WriteIndented = false, // less data used
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingDefault
+                               | System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+    };
+
+    /// <summary>
+    /// The information about the host where the EventBus is running.
+    /// </summary>
+    public HostInfo? HostInfo { get; set; }
+}

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -230,19 +230,16 @@ public class EventBus
 
     private async Task StartTransportsAsync(CancellationToken cancellationToken)
     {
-        if (options.Readiness.Enabled)
+        try
         {
-            try
-            {
-                // Perform readiness check before starting bus.
-                logger.StartupReadinessCheck();
-                await readinessProvider.WaitReadyAsync(cancellationToken: cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                logger.StartupReadinessCheckFailed(ex);
-                throw; // re-throw to prevent from getting healthy
-            }
+            // Perform readiness check before starting bus.
+            logger.StartupReadinessCheck();
+            await readinessProvider.WaitReadyAsync(cancellationToken: cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            logger.StartupReadinessCheckFailed(ex);
+            throw; // re-throw to prevent from getting healthy
         }
 
         // Start the bus and its transports

--- a/src/Tingle.EventBus/Readiness/DefaultReadinessProvider.cs
+++ b/src/Tingle.EventBus/Readiness/DefaultReadinessProvider.cs
@@ -13,10 +13,10 @@ internal class DefaultReadinessProvider : IReadinessProvider, IHealthCheckPublis
 
     private HealthReport? healthReport;
 
-    public DefaultReadinessProvider(IOptions<EventBusOptions> optionsAccessor,
+    public DefaultReadinessProvider(IOptions<EventBusReadinessOptions> optionsAccessor,
                                     ILogger<DefaultReadinessProvider> logger)
     {
-        options = optionsAccessor?.Value?.Readiness ?? throw new ArgumentNullException(nameof(optionsAccessor));
+        options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -22,7 +22,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
     /// </summary>
     /// <param name="optionsAccessor"></param>
     /// <param name="loggerFactory"></param>
-    protected AbstractEventSerializer(IOptionsMonitor<EventBusOptions> optionsAccessor, ILoggerFactory loggerFactory)
+    protected AbstractEventSerializer(IOptionsMonitor<EventBusSerializationOptions> optionsAccessor, ILoggerFactory loggerFactory)
     {
         OptionsAccessor = optionsAccessor ?? throw new ArgumentNullException(nameof(optionsAccessor));
 
@@ -39,7 +39,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
     protected abstract IList<string> SupportedMediaTypes { get; }
 
     ///
-    protected IOptionsMonitor<EventBusOptions> OptionsAccessor { get; }
+    protected IOptionsMonitor<EventBusSerializationOptions> OptionsAccessor { get; }
 
     ///
     protected ILogger Logger { get; }

--- a/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/DefaultJsonEventSerializer.cs
@@ -15,7 +15,7 @@ public class DefaultJsonEventSerializer : AbstractEventSerializer
     /// </summary>
     /// <param name="optionsAccessor">The options for configuring the serializer.</param>
     /// <param name="loggerFactory"></param>
-    public DefaultJsonEventSerializer(IOptionsMonitor<EventBusOptions> optionsAccessor,
+    public DefaultJsonEventSerializer(IOptionsMonitor<EventBusSerializationOptions> optionsAccessor,
                                       ILoggerFactory loggerFactory)
         : base(optionsAccessor, loggerFactory) { }
 

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializer.cs
@@ -15,7 +15,7 @@ public class XmlEventSerializer : AbstractEventSerializer
     /// </summary>
     /// <param name="optionsAccessor">The options for configuring the serializer.</param>
     /// <param name="loggerFactory"></param>
-    public XmlEventSerializer(IOptionsMonitor<EventBusOptions> optionsAccessor,
+    public XmlEventSerializer(IOptionsMonitor<EventBusSerializationOptions> optionsAccessor,
                               ILoggerFactory loggerFactory)
         : base(optionsAccessor, loggerFactory) { }
 


### PR DESCRIPTION
Serializers and readiness providers may be activated fairly early in an application such as one that uses an `IHostedService` to publish events via `IEventPublisher`. This results in multiple calls of the configuration methods for `EventBus` options and occasionally mis-configuration of events and failures in publishing.

This PR solves this by:
- Making `EventBusReadinessOptions` independent and configurable separately.
- Introducing a new `EventBusSerializationOptions` class which is also independent of `EventBusOptions`.