### PR TITLE
Make use of IValidateOptions<T>

### DIFF
--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Serializers;
+﻿using Tingle.EventBus.Serializers;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class EventBusBuilderExtensions
         // Configure the options for the serializer
         var services = builder.Services;
         if (configure != null) services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<NewtonsoftJsonSerializerOptions>, NewtonsoftJsonSerializerPostConfigureOptions>();
+        services.ConfigureOptions<NewtonsoftJsonSerializerPostConfigureOptions>();
 
         // Add the serializer
         return builder.UseDefaultSerializer<NewtonsoftJsonSerializer>();

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/EventBusBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class EventBusBuilderExtensions
         // Configure the options for the serializer
         var services = builder.Services;
         if (configure != null) services.Configure(configure);
-        services.ConfigureOptions<NewtonsoftJsonSerializerPostConfigureOptions>();
+        services.ConfigureOptions<NewtonsoftJsonSerializerConfigureOptions>();
 
         // Add the serializer
         return builder.UseDefaultSerializer<NewtonsoftJsonSerializer>();

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializerConfigureOptions.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializerConfigureOptions.cs
@@ -6,14 +6,16 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="NewtonsoftJsonSerializerOptions"/>.
 /// </summary>
-internal class NewtonsoftJsonSerializerConfigureOptions : IPostConfigureOptions<NewtonsoftJsonSerializerOptions>
+internal class NewtonsoftJsonSerializerConfigureOptions : IValidateOptions<NewtonsoftJsonSerializerOptions>
 {
-    public void PostConfigure(string name, NewtonsoftJsonSerializerOptions options)
+    public ValidateOptionsResult Validate(string name, NewtonsoftJsonSerializerOptions options)
     {
         // Ensure the settings are provided
         if (options.SerializerSettings == null)
         {
-            throw new InvalidOperationException($"'{nameof(options.SerializerSettings)}' must be provided");
+            return ValidateOptionsResult.Fail($"'{nameof(options.SerializerSettings)}' must be provided");
         }
+
+        return ValidateOptionsResult.Success;
     }
 }

--- a/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializerConfigureOptions.cs
+++ b/src/Tingle.EventBus.Serializers.NewtonsoftJson/NewtonsoftJsonSerializerConfigureOptions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="NewtonsoftJsonSerializerOptions"/>.
 /// </summary>
-internal class NewtonsoftJsonSerializerPostConfigureOptions : IPostConfigureOptions<NewtonsoftJsonSerializerOptions>
+internal class NewtonsoftJsonSerializerConfigureOptions : IPostConfigureOptions<NewtonsoftJsonSerializerOptions>
 {
     public void PostConfigure(string name, NewtonsoftJsonSerializerOptions options)
     {

--- a/src/Tingle.EventBus.Transports.Amazon.Abstractions/AmazonTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Abstractions/AmazonTransportConfigureOptions.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AmazonTransportOptions"/> derivatives.
 /// </summary>
-public abstract class AmazonTransportPostConfigureOptions<TOptions> : IPostConfigureOptions<TOptions> where TOptions : AmazonTransportOptions
+public abstract class AmazonTransportConfigureOptions<TOptions> : IPostConfigureOptions<TOptions> where TOptions : AmazonTransportOptions
 {
     /// <inheritdoc/>
     public virtual void PostConfigure(string name, TOptions options)

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AmazonKinesisTransportOptions"/>.
 /// </summary>
-internal class AmazonKinesisPostConfigureOptions : AmazonTransportPostConfigureOptions<AmazonKinesisTransportOptions>
+internal class AmazonKinesisConfigureOptions : AmazonTransportConfigureOptions<AmazonKinesisTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public AmazonKinesisPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public AmazonKinesisConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // Configure the options for Amazon Kinesis
         services.Configure(configure);
-        services.ConfigureOptions<AmazonKinesisPostConfigureOptions>();
+        services.ConfigureOptions<AmazonKinesisConfigureOptions>();
 
         // Register the transport
         builder.AddTransport<AmazonKinesisTransport, AmazonKinesisTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Amazon.Kinesis;
+﻿using Tingle.EventBus.Transports.Amazon.Kinesis;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // Configure the options for Amazon Kinesis
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<AmazonKinesisTransportOptions>, AmazonKinesisPostConfigureOptions>();
+        services.ConfigureOptions<AmazonKinesisPostConfigureOptions>();
 
         // Register the transport
         builder.AddTransport<AmazonKinesisTransport, AmazonKinesisTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AmazonSqsTransportOptions"/>.
 /// </summary>
-internal class AmazonSqsPostConfigureOptions : AmazonTransportPostConfigureOptions<AmazonSqsTransportOptions>
+internal class AmazonSqsConfigureOptions : AmazonTransportConfigureOptions<AmazonSqsTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public AmazonSqsPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public AmazonSqsConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Amazon SQS and SNS option
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<AmazonSqsTransportOptions>, AmazonSqsPostConfigureOptions>();
+        services.ConfigureOptions<AmazonSqsPostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AmazonSqsTransport, AmazonSqsTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Amazon SQS and SNS option
         services.Configure(configure);
-        services.ConfigureOptions<AmazonSqsPostConfigureOptions>();
+        services.ConfigureOptions<AmazonSqsConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AmazonSqsTransport, AmazonSqsTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Amazon.Sqs;
+﻿using Tingle.EventBus.Transports.Amazon.Sqs;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.Azure.Abstractions/AzureTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.Abstractions/AzureTransportConfigureOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AzureTransportOptions{TCredential}"/> derivatives.
 /// </summary>
-public abstract class AzureTransportPostConfigureOptions<TCredential, TOptions> : IPostConfigureOptions<TOptions>
+public abstract class AzureTransportConfigureOptions<TCredential, TOptions> : IPostConfigureOptions<TOptions>
     where TCredential : AzureTransportCredentials
     where TOptions : AzureTransportOptions<TCredential>
 {

--- a/src/Tingle.EventBus.Transports.Azure.Abstractions/AzureTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.Abstractions/AzureTransportConfigureOptions.cs
@@ -5,23 +5,31 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AzureTransportOptions{TCredential}"/> derivatives.
 /// </summary>
-public abstract class AzureTransportConfigureOptions<TCredential, TOptions> : IPostConfigureOptions<TOptions>
+public abstract class AzureTransportConfigureOptions<TCredential, TOptions> : IPostConfigureOptions<TOptions>, IValidateOptions<TOptions>
     where TCredential : AzureTransportCredentials
     where TOptions : AzureTransportOptions<TCredential>
 {
     /// <inheritdoc/>
     public virtual void PostConfigure(string name, TOptions options)
     {
+        // intentionally left bank for future use
+    }
+
+    /// <inheritdoc/>
+    public virtual ValidateOptionsResult Validate(string name, TOptions options)
+    {
         // We should either have a token credential or a connection string
         if (options.Credentials is null || options.Credentials.Value is null)
         {
-            throw new InvalidOperationException($"'{nameof(options.Credentials)}' must be provided in form a connection string or an instance of '{typeof(TCredential).Name}'.");
+            return ValidateOptionsResult.Fail($"'{nameof(options.Credentials)}' must be provided in form a connection string or an instance of '{typeof(TCredential).Name}'.");
         }
 
         // We must have TokenCredential if using TCredential
         if (options.Credentials.Value is TCredential tc && tc.TokenCredential is null)
         {
-            throw new InvalidOperationException($"'{nameof(tc.TokenCredential)}' must be provided when using '{typeof(TCredential).Name}'.");
+            return ValidateOptionsResult.Fail($"'{nameof(tc.TokenCredential)}' must be provided when using '{typeof(TCredential).Name}'.");
         }
+
+        return ValidateOptionsResult.Success;
     }
 }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AzureEventHubsTransportOptions"/>.
 /// </summary>
-internal class AzureEventHubsPostConfigureOptions : AzureTransportPostConfigureOptions<AzureEventHubsTransportCredentials, AzureEventHubsTransportOptions>
+internal class AzureEventHubsConfigureOptions : AzureTransportConfigureOptions<AzureEventHubsTransportCredentials, AzureEventHubsTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public AzureEventHubsPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public AzureEventHubsConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Azure.EventHubs;
+﻿using Tingle.EventBus.Transports.Azure.EventHubs;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Event Hubs
         services.Configure(configure);
-        services.ConfigureOptions<AzureEventHubsPostConfigureOptions>();
+        services.ConfigureOptions<AzureEventHubsConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureEventHubsTransport, AzureEventHubsTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Event Hubs
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<AzureEventHubsTransportOptions>, AzureEventHubsPostConfigureOptions>();
+        services.ConfigureOptions<AzureEventHubsPostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureEventHubsTransport, AzureEventHubsTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageConfigureOptions.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AzureQueueStorageTransportOptions"/>.
 /// </summary>
-internal class AzureQueueStoragePostConfigureOptions : AzureTransportPostConfigureOptions<AzureQueueStorageTransportCredentials, AzureQueueStorageTransportOptions>
+internal class AzureQueueStorageConfigureOptions : AzureTransportConfigureOptions<AzureQueueStorageTransportCredentials, AzureQueueStorageTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public AzureQueueStoragePostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public AzureQueueStorageConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Queue Storage
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<AzureQueueStorageTransportOptions>, AzureQueueStoragePostConfigureOptions>();
+        services.ConfigureOptions<AzureQueueStoragePostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureQueueStorageTransport, AzureQueueStorageTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Queue Storage
         services.Configure(configure);
-        services.ConfigureOptions<AzureQueueStoragePostConfigureOptions>();
+        services.ConfigureOptions<AzureQueueStorageConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureQueueStorageTransport, AzureQueueStorageTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Azure.QueueStorage;
+﻿using Tingle.EventBus.Transports.Azure.QueueStorage;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="AzureServiceBusTransportOptions"/>.
 /// </summary>
-internal class AzureServiceBusPostConfigureOptions : AzureTransportPostConfigureOptions<AzureServiceBusTransportCredentials, AzureServiceBusTransportOptions>
+internal class AzureServiceBusConfigureOptions : AzureTransportConfigureOptions<AzureServiceBusTransportCredentials, AzureServiceBusTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public AzureServiceBusPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public AzureServiceBusConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Service Bus
         services.Configure(configure);
-        services.ConfigureOptions<AzureServiceBusPostConfigureOptions>();
+        services.ConfigureOptions<AzureServiceBusConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureServiceBusTransport, AzureServiceBusTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Azure Service Bus
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<AzureServiceBusTransportOptions>, AzureServiceBusPostConfigureOptions>();
+        services.ConfigureOptions<AzureServiceBusPostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<AzureServiceBusTransport, AzureServiceBusTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Azure.ServiceBus;
+﻿using Tingle.EventBus.Transports.Azure.ServiceBus;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class EventBusBuilderExtensions
             services.Configure(configure);
         }
 
-        services.ConfigureOptions<InMemoryTransportPostConfigureOptions>();
+        services.ConfigureOptions<InMemoryTransportConfigureOptions>();
         services.AddSingleton<SequenceNumberGenerator>();
 
         // register the transport
@@ -64,7 +64,7 @@ public static class EventBusBuilderExtensions
         services.AddSingleton<InMemoryTestHarness>();
 
         // Set the delivery delay to zero for instance delivery
-        services.ConfigureOptions<InMemoryTestHarnessPostConfigureOptions>();
+        services.ConfigureOptions<InMemoryTestHarnessConfigureOptions>();
 
         return builder;
     }

--- a/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.InMemory;
+﻿using Tingle.EventBus.Transports.InMemory;
 using Tingle.EventBus.Transports.InMemory.Client;
 
 namespace Microsoft.Extensions.DependencyInjection;

--- a/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/EventBusBuilderExtensions.cs
@@ -28,7 +28,7 @@ public static class EventBusBuilderExtensions
             services.Configure(configure);
         }
 
-        services.AddSingleton<IPostConfigureOptions<InMemoryTransportOptions>, InMemoryTransportPostConfigureOptions>();
+        services.ConfigureOptions<InMemoryTransportPostConfigureOptions>();
         services.AddSingleton<SequenceNumberGenerator>();
 
         // register the transport
@@ -64,7 +64,7 @@ public static class EventBusBuilderExtensions
         services.AddSingleton<InMemoryTestHarness>();
 
         // Set the delivery delay to zero for instance delivery
-        services.AddSingleton<IPostConfigureOptions<InMemoryTestHarnessOptions>, InMemoryTestHarnessPostConfigureOptions>();
+        services.ConfigureOptions<InMemoryTestHarnessPostConfigureOptions>();
 
         return builder;
     }

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTestHarnessConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTestHarnessConfigureOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="InMemoryTestHarnessOptions"/>.
 /// </summary>
-internal class InMemoryTestHarnessPostConfigureOptions : IPostConfigureOptions<InMemoryTestHarnessOptions>
+internal class InMemoryTestHarnessConfigureOptions : IPostConfigureOptions<InMemoryTestHarnessOptions>
 {
     public void PostConfigure(string name, InMemoryTestHarnessOptions options)
     {

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
@@ -7,11 +7,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="InMemoryTransportOptions"/>.
 /// </summary>
-internal class InMemoryTransportPostConfigureOptions : IPostConfigureOptions<InMemoryTransportOptions>
+internal class InMemoryTransportConfigureOptions : IPostConfigureOptions<InMemoryTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public InMemoryTransportPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public InMemoryTransportConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Kafka
         services.Configure(configure);
-        services.ConfigureOptions<KafkaPostConfigureOptions>();
+        services.ConfigureOptions<KafkaConfigureOptions>();
 
         // register the transport
         builder.AddTransport<KafkaTransport, KafkaTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for Kafka
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<KafkaTransportOptions>, KafkaPostConfigureOptions>();
+        services.ConfigureOptions<KafkaPostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<KafkaTransport, KafkaTransportOptions>();

--- a/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.Kafka;
+﻿using Tingle.EventBus.Transports.Kafka;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="KafkaTransportOptions"/>.
 /// </summary>
-internal class KafkaPostConfigureOptions : IPostConfigureOptions<KafkaTransportOptions>
+internal class KafkaConfigureOptions : IPostConfigureOptions<KafkaTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public KafkaPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public KafkaConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for RabbitMQ
         services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<RabbitMqTransportOptions>, RabbitMqPostConfigureOptions>();
+        services.ConfigureOptions<RabbitMqPostConfigureOptions>();
 
         // register the transport
         builder.AddTransport<RabbitMqTransport, RabbitMqTransportOptions>();

--- a/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Transports.RabbitMQ;
+﻿using Tingle.EventBus.Transports.RabbitMQ;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/EventBusBuilderExtensions.cs
@@ -23,7 +23,7 @@ public static class EventBusBuilderExtensions
 
         // configure the options for RabbitMQ
         services.Configure(configure);
-        services.ConfigureOptions<RabbitMqPostConfigureOptions>();
+        services.ConfigureOptions<RabbitMqConfigureOptions>();
 
         // register the transport
         builder.AddTransport<RabbitMqTransport, RabbitMqTransportOptions>();

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="RabbitMqTransportOptions"/>.
 /// </summary>
-internal class RabbitMqPostConfigureOptions : IPostConfigureOptions<RabbitMqTransportOptions>
+internal class RabbitMqConfigureOptions : IPostConfigureOptions<RabbitMqTransportOptions>
 {
     private readonly EventBusOptions busOptions;
 
-    public RabbitMqPostConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
+    public RabbitMqConfigureOptions(IOptions<EventBusOptions> busOptionsAccessor)
     {
         busOptions = busOptionsAccessor?.Value ?? throw new ArgumentNullException(nameof(busOptionsAccessor));
     }

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -90,7 +90,7 @@ public class EventBusBuilder
         where TOptions : EventBusTransportOptionsBase
     {
         // Post configure the common transport options
-        Services.ConfigureOptions<TransportOptionsPostConfigureOptions<TOptions>>();
+        Services.ConfigureOptions<TransportOptionsConfigureOptions<TOptions>>();
 
         // Register for resolution
         Services.AddSingleton<IEventBusTransport, TTransport>();

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -90,7 +90,7 @@ public class EventBusBuilder
         where TOptions : EventBusTransportOptionsBase
     {
         // Post configure the common transport options
-        Services.AddSingleton<IPostConfigureOptions<TOptions>, TransportOptionsPostConfigureOptions<TOptions>>();
+        Services.ConfigureOptions<TransportOptionsPostConfigureOptions<TOptions>>();
 
         // Register for resolution
         Services.AddSingleton<IEventBusTransport, TTransport>();

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Extensions.Diagnostics.HealthChecks;
-using Microsoft.Extensions.Options;
 using Tingle.EventBus;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Ids;

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -144,6 +144,12 @@ internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>,
     /// <inheritdoc/>
     public ValidateOptionsResult Validate(string name, EventBusSerializationOptions options)
     {
+        // Ensure we have SerializerOptions set
+        if (options.SerializerOptions == null)
+        {
+            return ValidateOptionsResult.Fail($"'{nameof(options.SerializerOptions)}' must be set.");
+        }
+
         // Ensure we have HostInfo set
         if (options.HostInfo == null)
         {

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -13,7 +13,7 @@ internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>,
                                           IPostConfigureOptions<EventBusOptions>,
                                           IPostConfigureOptions<EventBusReadinessOptions>,
                                           IConfigureOptions<EventBusSerializationOptions>,
-                                          IPostConfigureOptions<EventBusSerializationOptions>
+                                          IValidateOptions<EventBusSerializationOptions>
 {
     private readonly IHostEnvironment environment;
     private readonly IEnumerable<IEventConfigurator> configurators;
@@ -134,12 +134,14 @@ internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>,
     }
 
     /// <inheritdoc/>
-    public void PostConfigure(string name, EventBusSerializationOptions options)
+    public ValidateOptionsResult Validate(string name, EventBusSerializationOptions options)
     {
         // Ensure we have HostInfo set
         if (options.HostInfo == null)
         {
-            throw new InvalidOperationException($"'{nameof(options.HostInfo)}' must be set.");
+            return ValidateOptionsResult.Fail($"'{nameof(options.HostInfo)}' must be set.");
         }
+
+        return ValidateOptionsResult.Success;
     }
 }

--- a/src/Tingle.EventBus/DependencyInjection/TransportOptionsConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/TransportOptionsConfigureOptions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// for shared settings in <see cref="EventBusTransportOptionsBase"/>.
 /// </summary>
 /// <typeparam name="T"></typeparam>
-internal class TransportOptionsPostConfigureOptions<T> : IPostConfigureOptions<T> where T : EventBusTransportOptionsBase
+internal class TransportOptionsConfigureOptions<T> : IPostConfigureOptions<T> where T : EventBusTransportOptionsBase
 {
     public void PostConfigure(string name, T options)
     {

--- a/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class EventBusBuilderExtensions
         // Configure the options for the serializer
         var services = builder.Services;
         if (configure != null) services.Configure(configure);
-        services.AddSingleton<IPostConfigureOptions<XmlEventSerializerOptions>, XmlEventSerializerPostConfigureOptions>();
+        services.ConfigureOptions<XmlEventSerializerPostConfigureOptions>();
 
         // Add the serializer
         return builder.UseDefaultSerializer<XmlEventSerializer>();

--- a/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Extensions.Options;
-using Tingle.EventBus.Serialization.Xml;
+﻿using Tingle.EventBus.Serialization.Xml;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/EventBusBuilderExtensions.cs
@@ -22,7 +22,7 @@ public static class EventBusBuilderExtensions
         // Configure the options for the serializer
         var services = builder.Services;
         if (configure != null) services.Configure(configure);
-        services.ConfigureOptions<XmlEventSerializerPostConfigureOptions>();
+        services.ConfigureOptions<XmlEventSerializerConfigureOptions>();
 
         // Add the serializer
         return builder.UseDefaultSerializer<XmlEventSerializer>();

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializerConfigureOptions.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializerConfigureOptions.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="XmlEventSerializerOptions"/>.
 /// </summary>
-internal class XmlEventSerializerPostConfigureOptions : IPostConfigureOptions<XmlEventSerializerOptions>
+internal class XmlEventSerializerConfigureOptions : IPostConfigureOptions<XmlEventSerializerOptions>
 {
     public void PostConfigure(string name, XmlEventSerializerOptions options)
     {

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializerConfigureOptions.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventSerializerConfigureOptions.cs
@@ -5,10 +5,10 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// <summary>
 /// A class to finish the configuration of instances of <see cref="XmlEventSerializerOptions"/>.
 /// </summary>
-internal class XmlEventSerializerConfigureOptions : IPostConfigureOptions<XmlEventSerializerOptions>
+internal class XmlEventSerializerConfigureOptions : IValidateOptions<XmlEventSerializerOptions>
 {
-    public void PostConfigure(string name, XmlEventSerializerOptions options)
+    public ValidateOptionsResult Validate(string name, XmlEventSerializerOptions options)
     {
-        // intentionally left blank for future use
+        return ValidateOptionsResult.Success;
     }
 }


### PR DESCRIPTION
This PR makes use of `services.ConfigureOptions<T>(...)` and `IValidateOptions<T>` to make configuration, post configuration and validation of options easier.