### PR TITLE
Minor code fixes

### DIFF
--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -140,8 +140,8 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
 
             // Add custom properties
             properties.Headers.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
-                          .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
-                          .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
+                              .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
+                              .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 
             // do actual publish
             Logger.LogInformation("Sending {Id} to '{ExchangeName}'. Scheduled: {Scheduled}",
@@ -216,8 +216,8 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
 
                 // Add custom properties
                 properties.Headers.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
-                              .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
-                              .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
+                                  .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
+                                  .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 
                 // add to batch
                 batch.Add(exchange: name, routingKey: "", mandatory: false, properties: properties, body: body);

--- a/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace System.Collections.Generic;
+﻿namespace Tingle.EventBus;
 
 /// <summary>
 /// Extension methods on <see cref="IDictionary{TKey, TValue}"/>

--- a/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
+++ b/src/Tingle.EventBus/Retries/IRetryableEventExtensions.cs
@@ -96,7 +96,14 @@ public static class IRetryableEventExtensions
         return @event.WithDelays(delays);
     }
 
-    private static T WithDelays<T>(this T @event, IEnumerable<TimeSpan> delays) where T : IRetryableEvent
+    /// <summary>
+    /// Sets pre-computed delay durations.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="event"></param>
+    /// <param name="delays">The delays to set.</param>
+    /// <returns></returns>
+    public static T WithDelays<T>(this T @event, IEnumerable<TimeSpan> delays) where T : IRetryableEvent
     {
         @event.Delays = delays.ToList();
         return @event;


### PR DESCRIPTION
- Change namespace for DictionaryExtensions from `System.Collections.Generic` to `Tingle.EventBus`.
- Expose `WithDelays<T>(...)` extension method.
- Indentation fixes in `RabbitMqTransport`.