### PR TITLE
Fix potential conflicts

### DIFF
--- a/samples/AmazonSqsAndSns/AmazonSqsAndSns.csproj
+++ b/samples/AmazonSqsAndSns/AmazonSqsAndSns.csproj
@@ -5,10 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Tingle.EventBus.Transports.Amazon.Sqs\Tingle.EventBus.Transports.Amazon.Sqs.csproj" />
   </ItemGroup>
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,7 +6,6 @@
     <TargetFrameworks>netstandard2.1;net6.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Deterministic>true</Deterministic>
-    <!--<IsPackable>true</IsPackable>-->
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Tingle.EventBus;
+﻿namespace System.Collections.Generic;
 
 /// <summary>
 /// Extension methods on <see cref="IDictionary{TKey, TValue}"/>


### PR DESCRIPTION
- Revert namespace change for `DictionaryExtensions` in #444
- Remove commented out `<IsPackable>` element.
- Remove duplicate `PackageReference` for `Microsoft.Extensions.Hosting`.