### PR TITLE
Track Cancelled events for InMemory

### DIFF
--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTestHarness.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTestHarness.cs
@@ -76,6 +76,26 @@ public class InMemoryTestHarness
     }
 
     /// <summary>
+    /// Gets all the cancelled events.
+    /// </summary>
+    public IEnumerable<long> Cancelled() => transport.Cancelled;
+
+    /// <summary>
+    /// Gets all the cancelled events.
+    /// </summary>
+    /// <param name="delay">
+    /// The duration of time to delay.
+    /// When <see langword="null"/>, the default value (<see cref="InMemoryTestHarnessOptions.DefaultDelay"/>) is used
+    /// </param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    public async Task<IEnumerable<long>> CancelledAsync(TimeSpan? delay = null, CancellationToken cancellationToken = default)
+    {
+        await Task.Delay(delay ?? options.DefaultDelay, cancellationToken);
+        return Cancelled();
+    }
+
+    /// <summary>
     /// Gets all the consumed events.
     /// </summary>
     public IEnumerable<EventContext> Consumed() => transport.Consumed;

--- a/tests/Tingle.EventBus.Transports.InMemory.Tests/SimpleCancellationTests.cs
+++ b/tests/Tingle.EventBus.Transports.InMemory.Tests/SimpleCancellationTests.cs
@@ -1,0 +1,59 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Tingle.EventBus.Transports.InMemory;
+
+namespace Tingle.EventBus.Tests.InMemory;
+
+public class SimpleCancellationTests
+{
+    [Fact]
+    public async Task EventIsPublishedOnBusAsync()
+    {
+        var host = Host.CreateDefaultBuilder()
+                       .ConfigureServices((context, services) =>
+                       {
+                           services.AddEventBus(builder =>
+                           {
+                               builder.AddInMemoryTransport();
+                               builder.AddInMemoryTestHarness();
+                           });
+                       })
+                       .Build();
+
+        var provider = host.Services;
+        var harness = provider.GetRequiredService<InMemoryTestHarness>();
+        await harness.StartAsync();
+        try
+        {
+            var publisher = provider.GetRequiredService<IEventPublisher>();
+            var evt = new DoorOpenedEvent
+            {
+                Make = "TESLA",
+                Model = "Roadster 2.0",
+                Registration = "1234567890",
+                VIN = "5YJ3E1EA5KF328931",
+                Year = 2021,
+            };
+            var schedulingId = (string?)await publisher.PublishAsync(@event: evt, scheduled: DateTimeOffset.UtcNow.AddDays(1));
+            Assert.NotNull(schedulingId);
+
+            // Ensure no failures
+            Assert.False(harness.Failed().Any());
+
+            // Ensure only one was published
+            Assert.Single(harness.Published<DoorOpenedEvent>());
+
+            await publisher.CancelAsync<DoorOpenedEvent>(schedulingId);
+
+            // Ensure only one was cancelled
+            var sn = Assert.Single(harness.Cancelled());
+            Assert.Equal(schedulingId, sn.ToString());
+        }
+        finally
+        {
+            await harness.StopAsync();
+        }
+    }
+
+    class DoorOpenedEvent : SimpleConsumer.SampleEvent { }
+}

--- a/tests/Tingle.EventBus.Transports.InMemory.Tests/SimplePublisherTests.cs
+++ b/tests/Tingle.EventBus.Transports.InMemory.Tests/SimplePublisherTests.cs
@@ -33,12 +33,12 @@ public class SimplePublisherTests
             var orderProcessor = provider.GetRequiredService<RandomOrderProcessor>();
             await orderProcessor.ProcessAsync(orderNumber);
 
+            // Ensure no failures
+            Assert.False(harness.Failed().Any());
+
             // expect publish for event order numbers
             if ((orderNumber % 2) == 0)
             {
-                // Ensure no failures
-                Assert.False(harness.Failed().Any());
-
                 // Ensure only one was published
                 var context = Assert.Single(harness.Published<OrderProcessedEvent>());
                 var evt = context.Event;
@@ -46,9 +46,6 @@ public class SimplePublisherTests
             }
             else
             {
-                // Ensure no failures
-                Assert.False(harness.Failed().Any());
-
                 // Ensure nothing was published
                 Assert.False(harness.Published().Any());
             }


### PR DESCRIPTION
Expose cancelled sequence numbers in `InMemoryTestHarness` and in `InMemoryTransport`.