### PR TITLE
Retries for publish and cancel

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
@@ -156,15 +156,15 @@ public class AmazonKinesisTransport : EventBusTransportBase<AmazonKinesisTranspo
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(string id,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(string id,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Amazon Kinesis does not support canceling published events.");
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(IList<string> ids,
+    protected override Task CancelCoreAsync<TEvent>(IList<string> ids,
                                              EventRegistration registration,
                                              CancellationToken cancellationToken = default)
     {

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
@@ -63,10 +63,10 @@ public class AmazonKinesisTransport : EventBusTransportBase<AmazonKinesisTranspo
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled message
         if (scheduled != null)
@@ -99,10 +99,10 @@ public class AmazonKinesisTransport : EventBusTransportBase<AmazonKinesisTranspo
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled message
         if (scheduled != null)

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -95,10 +95,10 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         using var scope = CreateScope();
         var body = await SerializeAsync(scope: scope,
@@ -159,10 +159,10 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         using var scope = CreateScope();
         var sequenceNumbers = new List<string>();

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -246,17 +246,17 @@ public class AmazonSqsTransport : EventBusTransportBase<AmazonSqsTransportOption
 
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(string id,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(string id,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Amazon SNS does not support canceling published messages.");
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(IList<string> ids,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Amazon SNS does not support canceling published messages.");
     }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -210,17 +210,17 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(string id,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(string id,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Azure EventHubs does not support canceling published events.");
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(IList<string> ids,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Azure EventHubs does not support canceling published events.");
     }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -103,10 +103,10 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled event
         if (scheduled != null)
@@ -154,10 +154,10 @@ public class AzureEventHubsTransport : EventBusTransportBase<AzureEventHubsTrans
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled events
         if (scheduled != null)

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -79,10 +79,10 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         using var scope = CreateScope();
         var body = await SerializeAsync(scope: scope,
@@ -112,10 +112,10 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         // log warning when doing batch
         Logger.BatchingNotSupported();

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -152,9 +152,9 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(string id,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(string id,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
@@ -175,9 +175,9 @@ public class AzureQueueStorageTransport : EventBusTransportBase<AzureQueueStorag
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(IList<string> ids,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (ids is null)
         {

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -112,10 +112,10 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         using var scope = CreateScope();
         var body = await SerializeAsync(scope: scope,
@@ -171,10 +171,10 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         using var scope = CreateScope();
         var messages = new List<ServiceBusMessage>();

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -236,9 +236,9 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(string id,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(string id,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
@@ -257,9 +257,9 @@ public class AzureServiceBusTransport : EventBusTransportBase<AzureServiceBusTra
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(IList<string> ids,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (ids is null)
         {

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -235,9 +235,9 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(string id,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(string id,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(id))
         {
@@ -259,9 +259,9 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task CancelAsync<TEvent>(IList<string> ids,
-                                                   EventRegistration registration,
-                                                   CancellationToken cancellationToken = default)
+    protected override async Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                          EventRegistration registration,
+                                                          CancellationToken cancellationToken = default)
     {
         if (ids is null) throw new ArgumentNullException(nameof(ids));
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -120,10 +120,10 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled message
         if (scheduled != null)
@@ -174,10 +174,10 @@ public class InMemoryTransport : EventBusTransportBase<InMemoryTransportOptions>
     }
 
     /// <inheritdoc/>
-    public async override Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected async override Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled message
         if (scheduled != null)

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -193,17 +193,17 @@ public class KafkaTransport : EventBusTransportBase<KafkaTransportOptions>, IDis
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(string id,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(string id,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Kafka does not support canceling published events.");
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(IList<string> ids,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("Kafka does not support canceling published events.");
     }

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -107,10 +107,10 @@ public class KafkaTransport : EventBusTransportBase<KafkaTransportOptions>, IDis
     }
 
     /// <inheritdoc/>
-    public async override Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected async override Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         // log warning when trying to publish scheduled message
         if (scheduled != null)
@@ -144,10 +144,10 @@ public class KafkaTransport : EventBusTransportBase<KafkaTransportOptions>, IDis
     }
 
     /// <inheritdoc/>
-    public async override Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected async override Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         // log warning when doing batch
         Logger.BatchingNotSupported();

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -87,10 +87,10 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
-                                                                      EventRegistration registration,
-                                                                      DateTimeOffset? scheduled = null,
-                                                                      CancellationToken cancellationToken = default)
+    protected override async Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
+                                                                             EventRegistration registration,
+                                                                             DateTimeOffset? scheduled = null,
+                                                                             CancellationToken cancellationToken = default)
     {
         if (!IsConnected)
         {
@@ -158,10 +158,10 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
-                                                                             EventRegistration registration,
-                                                                             DateTimeOffset? scheduled = null,
-                                                                             CancellationToken cancellationToken = default)
+    protected override async Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
+                                                                                    EventRegistration registration,
+                                                                                    DateTimeOffset? scheduled = null,
+                                                                                    CancellationToken cancellationToken = default)
     {
         if (!IsConnected)
         {

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -237,17 +237,17 @@ public class RabbitMqTransport : EventBusTransportBase<RabbitMqTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(string id,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(string id,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("RabbitMQ does not support canceling published messages.");
     }
 
     /// <inheritdoc/>
-    public override Task CancelAsync<TEvent>(IList<string> ids,
-                                             EventRegistration registration,
-                                             CancellationToken cancellationToken = default)
+    protected override Task CancelCoreAsync<TEvent>(IList<string> ids,
+                                                    EventRegistration registration,
+                                                    CancellationToken cancellationToken = default)
     {
         throw new NotSupportedException("RabbitMQ does not support canceling published messages.");
     }

--- a/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
@@ -41,23 +41,6 @@ public class EventConsumerRegistration : IEquatable<EventConsumerRegistration>
     public ICollection<string>? ReadinessTags { get; set; }
 
     /// <summary>
-    /// The retry policy to apply when consuming events.
-    /// This is an outer wrapper around the
-    /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, CancellationToken)"/>
-    /// method.
-    /// When set to <see langword="null"/>, the method is only invoked once.
-    /// Defaults to <see langword="null"/>.
-    /// When this value is set, it overrides the default value set on the transport or the bus.
-    /// </summary>
-    /// <remarks>
-    /// When a value is provided, the transport may extend the lock for the
-    /// message until the execution with retry policy completes successfully or not.
-    /// In such a case, ensure the execution timeout (sometimes called the visibility timeout
-    /// or lock duration) is set to accommodate the longest possible duration of the retry policy.
-    /// </remarks>
-    public AsyncRetryPolicy? RetryPolicy { get; set; }
-
-    /// <summary>
     /// The behaviour for unhandled errors when consuming events via the
     /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, CancellationToken)"/>
     /// method.
@@ -67,7 +50,7 @@ public class EventConsumerRegistration : IEquatable<EventConsumerRegistration>
     /// Defaults to <see langword="null"/>.
     /// When this value is set, it overrides the default value set on the transport or the bus.
     /// <br/>
-    /// When a <see cref="RetryPolicy"/> is in force, only errors not handled by it will be subject to the value set here.
+    /// When a retry policy is in force, only errors not handled by it will be subject to the value set here.
     /// </summary>
     public UnhandledConsumerErrorBehaviour? UnhandledErrorBehaviour { get; set; }
 
@@ -99,6 +82,8 @@ public class EventConsumerRegistration : IEquatable<EventConsumerRegistration>
     /// </summary>
     /// <returns>The <see cref="EventConsumerRegistration"/> for further configuration.</returns>
     public EventConsumerRegistration OnErrorDiscard() => OnError(UnhandledConsumerErrorBehaviour.Discard);
+
+    internal AsyncRetryPolicy? RetryPolicy { get; set; }
 
     #region Equality Overrides
 

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -1,4 +1,5 @@
-﻿using Tingle.EventBus.Serialization;
+﻿using Polly.Retry;
+using Tingle.EventBus.Serialization;
 
 namespace Tingle.EventBus.Configuration;
 
@@ -48,6 +49,17 @@ public class EventRegistration : IEquatable<EventRegistration?>
     /// This type must implement <see cref="IEventSerializer"/>.
     /// </summary>
     public Type? EventSerializerType { get; set; }
+
+    /// <summary>
+    /// The retry policy to apply when publishing events.
+    /// This is an outer wrapper around the
+    /// <see cref="IEventPublisher.PublishAsync{TEvent}(EventContext{TEvent}, DateTimeOffset?, CancellationToken)"/>
+    /// method.
+    /// When set to <see langword="null"/>, the method is only invoked once.
+    /// Defaults to <see langword="null"/>.
+    /// When this value is set, it overrides the default value set on the transport or the bus.
+    /// </summary>
+    public AsyncRetryPolicy? PublishRetryPolicy { get; set; }
 
     /// <summary>
     /// The list of consumers registered for this event.

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -51,15 +51,18 @@ public class EventRegistration : IEquatable<EventRegistration?>
     public Type? EventSerializerType { get; set; }
 
     /// <summary>
-    /// The retry policy to apply when publishing events.
-    /// This is an outer wrapper around the
-    /// <see cref="IEventPublisher.PublishAsync{TEvent}(EventContext{TEvent}, DateTimeOffset?, CancellationToken)"/>
-    /// method.
-    /// When set to <see langword="null"/>, the method is only invoked once.
+    /// The retry policy to apply when in addition to what may be provided by the SDKs for each transport.
+    /// When set to <see langword="null"/>, no additional retry policy is applied.
     /// Defaults to <see langword="null"/>.
     /// When this value is set, it overrides the default value set on the transport or the bus.
     /// </summary>
-    public AsyncRetryPolicy? PublishRetryPolicy { get; set; }
+    /// <remarks>
+    /// When a value is provided, the transport may extend the lock for the
+    /// message during consumption until the execution with retry policy completes successfully or not.
+    /// In such a case, ensure the execution timeout (sometimes called the visibility timeout
+    /// or lock duration) is set to accommodate the longest possible duration of the retry policy.
+    /// </remarks>
+    public AsyncRetryPolicy? RetryPolicy { get; set; }
 
     /// <summary>
     /// The list of consumers registered for this event.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -52,6 +52,14 @@ public class EventBusOptions
     public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
 
     /// <summary>
+    /// Optional default retry policy to use for publishing where it is not specified.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.PublishRetryPolicy"/> option.
+    /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultPublishRetryPolicy"/> option on the specific transport.
+    /// Defaults to <see langword="null"/>.
+    /// </summary>
+    public AsyncRetryPolicy? DefaultPublishRetryPolicy { get; set; }
+
+    /// <summary>
     /// Optional default retry policy to use for consumers where it is not specified.
     /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.
     /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultConsumerRetryPolicy"/> option on the specific transport.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -52,20 +52,12 @@ public class EventBusOptions
     public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
 
     /// <summary>
-    /// Optional default retry policy to use for publishing where it is not specified.
-    /// To specify a value per consumer, use the <see cref="EventRegistration.PublishRetryPolicy"/> option.
-    /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultPublishRetryPolicy"/> option on the specific transport.
+    /// Optional default retry policy to use where it is not specified.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.RetryPolicy"/> option.
+    /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultRetryPolicy"/> option on the specific transport.
     /// Defaults to <see langword="null"/>.
     /// </summary>
-    public AsyncRetryPolicy? DefaultPublishRetryPolicy { get; set; }
-
-    /// <summary>
-    /// Optional default retry policy to use for consumers where it is not specified.
-    /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.
-    /// To specify a value per transport, use the <see cref="EventBusTransportOptionsBase.DefaultConsumerRetryPolicy"/> option on the specific transport.
-    /// Defaults to <see langword="null"/>.
-    /// </summary>
-    public AsyncRetryPolicy? DefaultConsumerRetryPolicy { get; set; }
+    public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -98,9 +98,13 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
+            // Set publish retry policy
+            reg.PublishRetryPolicy ??= TransportOptions.DefaultPublishRetryPolicy;
+            reg.PublishRetryPolicy ??= BusOptions.DefaultPublishRetryPolicy;
+
             foreach (var ecr in reg.Consumers)
             {
-                // Set retry policy
+                // Set consumer retry policy
                 ecr.RetryPolicy ??= TransportOptions.DefaultConsumerRetryPolicy;
                 ecr.RetryPolicy ??= BusOptions.DefaultConsumerRetryPolicy;
 

--- a/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportBase.cs
@@ -72,7 +72,7 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
         where TEvent : class
     {
         // publish, with retry if specified
-        var retryPolicy = registration.PublishRetryPolicy;
+        var retryPolicy = registration.RetryPolicy;
         if (retryPolicy != null)
         {
             return await retryPolicy.ExecuteAsync(ct => PublishCoreAsync(@event, registration, scheduled, ct), cancellationToken);
@@ -91,7 +91,7 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
         where TEvent : class
     {
         // publish, with retry if specified
-        var retryPolicy = registration.PublishRetryPolicy;
+        var retryPolicy = registration.RetryPolicy;
         if (retryPolicy != null)
         {
             return await retryPolicy.ExecuteAsync(ct => PublishCoreAsync(events, registration, scheduled, ct), cancellationToken);
@@ -141,14 +141,12 @@ public abstract class EventBusTransportBase<TTransportOptions> : IEventBusTransp
         foreach (var reg in registrations)
         {
             // Set publish retry policy
-            reg.PublishRetryPolicy ??= TransportOptions.DefaultPublishRetryPolicy;
-            reg.PublishRetryPolicy ??= BusOptions.DefaultPublishRetryPolicy;
+            reg.RetryPolicy ??= TransportOptions.DefaultRetryPolicy;
+            reg.RetryPolicy ??= BusOptions.DefaultRetryPolicy;
 
             foreach (var ecr in reg.Consumers)
             {
-                // Set consumer retry policy
-                ecr.RetryPolicy ??= TransportOptions.DefaultConsumerRetryPolicy;
-                ecr.RetryPolicy ??= BusOptions.DefaultConsumerRetryPolicy;
+                ecr.RetryPolicy = reg.RetryPolicy;
 
                 // Set unhandled error behaviour
                 ecr.UnhandledErrorBehaviour ??= TransportOptions.DefaultUnhandledConsumerErrorBehaviour;

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
@@ -49,6 +49,13 @@ public abstract class EventBusTransportOptionsBase
     public EventIdFormat? DefaultEventIdFormat { get; set; }
 
     /// <summary>
+    /// Optional default retry policy to use for publishing where it is not specified.
+    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultPublishRetryPolicy"/>.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.PublishRetryPolicy"/> option.
+    /// </summary>
+    public AsyncRetryPolicy? DefaultPublishRetryPolicy { get; set; }
+
+    /// <summary>
     /// Optional default retry policy to use for consumers where it is not specified.
     /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultConsumerRetryPolicy"/>.
     /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptionsBase.cs
@@ -49,18 +49,11 @@ public abstract class EventBusTransportOptionsBase
     public EventIdFormat? DefaultEventIdFormat { get; set; }
 
     /// <summary>
-    /// Optional default retry policy to use for publishing where it is not specified.
-    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultPublishRetryPolicy"/>.
-    /// To specify a value per consumer, use the <see cref="EventRegistration.PublishRetryPolicy"/> option.
+    /// Optional default retry policy to use where it is not specified.
+    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultRetryPolicy"/>.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.RetryPolicy"/> option.
     /// </summary>
-    public AsyncRetryPolicy? DefaultPublishRetryPolicy { get; set; }
-
-    /// <summary>
-    /// Optional default retry policy to use for consumers where it is not specified.
-    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultConsumerRetryPolicy"/>.
-    /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.RetryPolicy"/> option.
-    /// </summary>
-    public AsyncRetryPolicy? DefaultConsumerRetryPolicy { get; set; }
+    public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.


### PR DESCRIPTION
This PR adds support for retry policy when publishing and canceling events. This is useful when working with cloud providers who implement throttling such as Azure Service Bus and the SDK does not handle such scenarios. See https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-throttling
This retry policy is shared in the consumer too.