### PR TITLE
Wrap retry policies

### DIFF
--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -78,8 +78,11 @@ public class EventRegistration : IEquatable<EventRegistration?>
     /// </summary>
     public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
 
+    /// <summary>Whether the execution policies have been merged.</summary>
+    internal bool MergedExecutionPolicies { get; set; } = false;
+
     /// <summary>The final policy used in executions for the event and it's consumers.</summary>
-    internal IAsyncPolicy MergedPolicy { get; set; } = Policy.NoOpAsync();
+    internal IAsyncPolicy ExecutionPolicy { get; set; } = Policy.NoOpAsync();
 
     #region Equality Overrides
 

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -1,4 +1,5 @@
-﻿using Polly.Retry;
+﻿using Polly;
+using Polly.Retry;
 using Tingle.EventBus.Serialization;
 
 namespace Tingle.EventBus.Configuration;
@@ -76,6 +77,9 @@ public class EventRegistration : IEquatable<EventRegistration?>
     /// of the event bus such as the bus, the transport or the serializer.
     /// </summary>
     public IDictionary<string, object> Metadata { get; set; } = new Dictionary<string, object>();
+
+    /// <summary>The final policy used in executions for the event and it's consumers.</summary>
+    internal IAsyncPolicy MergedPolicy { get; set; } = Policy.NoOpAsync();
 
     #region Equality Overrides
 

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -51,10 +51,9 @@ public class EventRegistration : IEquatable<EventRegistration?>
     public Type? EventSerializerType { get; set; }
 
     /// <summary>
-    /// The retry policy to apply when in addition to what may be provided by the SDKs for each transport.
-    /// When set to <see langword="null"/>, no additional retry policy is applied.
-    /// Defaults to <see langword="null"/>.
-    /// When this value is set, it overrides the default value set on the transport or the bus.
+    /// The retry policy to apply specifically for this event.
+    /// This is in addition to what may be provided by the SDKs for each transport.
+    /// When provided alongside policies on the transport and the bus, it is used as the inner most policy.
     /// </summary>
     /// <remarks>
     /// When a value is provided, the transport may extend the lock for the

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -25,6 +25,17 @@ public class EventBusOptions
     public EventBusNamingOptions Naming { get; } = new EventBusNamingOptions();
 
     /// <summary>
+    /// Optional retry policy to apply to the bus.
+    /// When provided alongside policies on the transport and the event registration, it is used as the putter most policy.
+    /// Defaults to <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
+    /// To specify a value on a transport, use <see cref="EventBusTransportOptions.RetryPolicy"/> for the specific transport.
+    /// </remarks>
+    public AsyncRetryPolicy? RetryPolicy { get; set; }
+
+    /// <summary>
     /// Indicates if the messages/events produced require guard against duplicate messages.
     /// If <see langword="true"/>, duplicate messages having the same <see cref="EventContext.Id"/>
     /// sent to the same destination within a duration of <see cref="DuplicateDetectionDuration"/> will be discarded.
@@ -52,17 +63,6 @@ public class EventBusOptions
     /// Defaults to <see cref="EventIdFormat.Guid"/>.
     /// </summary>
     public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
-
-    /// <summary>
-    /// Optional retry policy to apply to the bus.
-    /// When provided alongside policies on the transport and the event registration, it is used as the putter most policy.
-    /// Defaults to <see langword="null"/>.
-    /// </summary>
-    /// <remarks>
-    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
-    /// To specify a value on a transport, use <see cref="EventBusTransportOptions.DefaultRetryPolicy"/> for the specific transport.
-    /// </remarks>
-    public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -54,11 +54,14 @@ public class EventBusOptions
     public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
 
     /// <summary>
-    /// Optional default retry policy to use where it is not specified.
-    /// To specify a value per consumer, use the <see cref="EventRegistration.RetryPolicy"/> option.
-    /// To specify a value per transport, use the <see cref="EventBusTransportOptions.DefaultRetryPolicy"/> option on the specific transport.
+    /// Optional retry policy to apply to the bus.
+    /// When provided alongside policies on the transport and the event registration, it is used as the putter most policy.
     /// Defaults to <see langword="null"/>.
     /// </summary>
+    /// <remarks>
+    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
+    /// To specify a value on a transport, use <see cref="EventBusTransportOptions.DefaultRetryPolicy"/> for the specific transport.
+    /// </remarks>
     public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>

--- a/src/Tingle.EventBus/PollyHelper.cs
+++ b/src/Tingle.EventBus/PollyHelper.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Polly;
+using Tingle.EventBus.Configuration;
+using Tingle.EventBus.Transports;
+
+namespace Tingle.EventBus;
+
+internal static class PollyHelper
+{
+    public static void Combine(EventBusOptions busOptions, EventBusTransportOptions transportOptions, EventRegistration registration)
+    {
+        if (busOptions is null) throw new ArgumentNullException(nameof(busOptions));
+        if (transportOptions is null) throw new ArgumentNullException(nameof(transportOptions));
+        if (registration is null) throw new ArgumentNullException(nameof(registration));
+
+        // if the policies have been merged, there is no need to repeat the process
+        if (registration.MergedExecutionPolicies) return;
+
+        registration.ExecutionPolicy = CombineInternal(busOptions, transportOptions, registration);
+        registration.MergedExecutionPolicies = true;
+    }
+
+    private static IAsyncPolicy CombineInternal(EventBusOptions busOptions, EventBusTransportOptions transportOptions, EventRegistration registration)
+    {
+        var policies = new IAsyncPolicy?[] {
+            busOptions.RetryPolicy,          // outer
+            transportOptions.RetryPolicy,
+            registration.RetryPolicy,               // inner
+        }.Where(p => p is not null).Select(p => p!).ToArray();
+
+        return policies.Length switch
+        {
+            0 => Policy.NoOpAsync(),            // if there are none, return No-Op, if
+            1 => policies[0],                   // a single policy can just be used (no need to combine)
+            _ => Policy.WrapAsync(policies),    // more than one needs to be combined
+        };
+    }
+}

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -81,8 +81,8 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         foreach (var reg in registrations)
         {
             // Set publish retry policy
-            reg.RetryPolicy ??= Options.DefaultRetryPolicy;
-            reg.RetryPolicy ??= BusOptions.DefaultRetryPolicy;
+            reg.RetryPolicy ??= Options.RetryPolicy;
+            reg.RetryPolicy ??= BusOptions.RetryPolicy;
 
             foreach (var ecr in reg.Consumers)
             {

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
@@ -10,6 +10,18 @@ namespace Tingle.EventBus.Transports;
 public abstract class EventBusTransportOptions
 {
     /// <summary>
+    /// Optional retry policy to apply specifically for this transport.
+    /// This is in addition to what may be provided by the transport SDKs.
+    /// When provided alongside policies on the bus and the event registration,
+    /// it is configured inner to the one on the bus and outer to the one on the event registration.
+    /// </summary>
+    /// <remarks>
+    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
+    /// To specify a value on the bus, use <see cref="EventBusOptions.RetryPolicy"/>.
+    /// </remarks>
+    public AsyncRetryPolicy? RetryPolicy { get; set; }
+
+    /// <summary>
     /// The delay to introduce every time zero messages are received.
     /// This eases on the CPU consumption and reduces the query costs.
     /// The default value is 1 minute. Max value is 10 minutes and minimum is 30 seconds.
@@ -47,18 +59,6 @@ public abstract class EventBusTransportOptions
     /// To specify a value per consumer, use the <see cref="EventRegistration.IdFormat"/> option.
     /// </summary>
     public EventIdFormat? DefaultEventIdFormat { get; set; }
-
-    /// <summary>
-    /// Optional retry policy to apply specifically for this transport.
-    /// This is in addition to what may be provided by the transport SDKs.
-    /// When provided alongside policies on the bus and the event registration,
-    /// it is configured inner to the one on the bus and outer to the one on the event registration.
-    /// </summary>
-    /// <remarks>
-    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
-    /// To specify a value on the bus, use <see cref="EventBusOptions.DefaultRetryPolicy"/>.
-    /// </remarks>
-    public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
@@ -49,10 +49,15 @@ public abstract class EventBusTransportOptions
     public EventIdFormat? DefaultEventIdFormat { get; set; }
 
     /// <summary>
-    /// Optional default retry policy to use where it is not specified.
-    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultRetryPolicy"/>.
-    /// To specify a value per consumer, use the <see cref="EventRegistration.RetryPolicy"/> option.
+    /// Optional retry policy to apply specifically for this transport.
+    /// This is in addition to what may be provided by the transport SDKs.
+    /// When provided alongside policies on the bus and the event registration,
+    /// it is configured inner to the one on the bus and outer to the one on the event registration.
     /// </summary>
+    /// <remarks>
+    /// To specify a value on an event registration, use <see cref="EventRegistration.RetryPolicy"/>.
+    /// To specify a value on the bus, use <see cref="EventBusOptions.DefaultRetryPolicy"/>.
+    /// </remarks>
     public AsyncRetryPolicy? DefaultRetryPolicy { get; set; }
 
     /// <summary>


### PR DESCRIPTION
This PR add support to combine retry policies on the bus, the transport, and the event registration using [Polly wrapping](https://github.com/App-vNext/Polly/wiki/PolicyWrap). This allows for better separation of concerns by having standard configuration of some retries/exceptions in the bus and the transport instead of overriding the bus and transport ones.