### PR TITLE
Wait transport startup

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
@@ -34,7 +34,7 @@ public class AmazonKinesisTransport : EventBusTransport<AmazonKinesisTransportOp
     }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -48,7 +48,7 @@ public class AmazonKinesisTransport : EventBusTransport<AmazonKinesisTransportOp
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisTransport.cs
@@ -34,10 +34,8 @@ public class AmazonKinesisTransport : EventBusTransport<AmazonKinesisTransportOp
     }
 
     /// <inheritdoc/>
-    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
+    protected override Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         // if there are consumers for this transport, throw exception
         var registrations = GetRegistrations();
         if (registrations.Count > 0)
@@ -45,13 +43,13 @@ public class AmazonKinesisTransport : EventBusTransport<AmazonKinesisTransportOp
             // Consuming is not yet supported on this bus due to it's complexity
             throw new NotSupportedException("Amazon Kinesis does not support consumers yet due to complexity requirements from KCL.");
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
-    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
+    protected override Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         // if there are consumers for this transport, throw exception
         var registrations = GetRegistrations();
         if (registrations.Count > 0)
@@ -59,6 +57,8 @@ public class AmazonKinesisTransport : EventBusTransport<AmazonKinesisTransportOp
             // Consuming is not yet supported on this bus due to it's complexity
             throw new NotSupportedException("Amazon Kinesis does not support consumers yet due to complexity requirements from KCL.");
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -52,8 +52,6 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
     /// <inheritdoc/>
     protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
@@ -75,8 +73,6 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         // Stop called without start or there was no consumers registered
         if (receiverTasks.Count == 0) return;
 

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -50,7 +50,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
     }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -73,7 +73,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -39,8 +39,6 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
     /// <inheritdoc/>
     protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
@@ -78,8 +76,6 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         var clients = processorsCache.Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
         foreach (var (key, proc) in clients)
         {

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -37,7 +37,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
         : base(serviceScopeFactory, busOptionsAccessor, optionsMonitor, loggerFactory) { }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -76,7 +76,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -44,7 +44,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
     }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -60,7 +60,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -44,10 +44,8 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
     }
 
     /// <inheritdoc/>
-    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
+    protected override Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
@@ -57,13 +55,13 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
                 receiverTasks.Add(t);
             }
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         // Stop called without start or there was no consumers registered
         if (receiverTasks.Count == 0) return;
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -71,8 +71,6 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
     /// <inheritdoc/>
     protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         // Get the namespace properties once at the start
         _ = await GetNamespacePropertiesAsync(cancellationToken).ConfigureAwait(false);
 
@@ -103,8 +101,6 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         var clients = processorsCache.Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
         foreach (var (key, proc) in clients)
         {

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -69,7 +69,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
     }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -101,7 +101,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -66,7 +66,7 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
     internal ConcurrentBag<EventContext> Failed => failed;
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -95,7 +95,7 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -68,8 +68,6 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
     /// <inheritdoc/>
     protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
@@ -97,8 +95,6 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         var clients = processorsCache.Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
         foreach (var (key, proc) in clients)
         {

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -71,7 +71,7 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
     }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -88,7 +88,7 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -71,10 +71,8 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
     }
 
     /// <inheritdoc/>
-    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
+    protected override Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         var registrations = GetRegistrations();
         var topics = registrations.Where(r => r.Consumers.Count > 0) // filter out those with consumers
                                   .Select(r => r.EventName) // pick the event name which is also the topic name
@@ -85,13 +83,13 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
             consumer.Value.Subscribe(topics);
             _ = ProcessAsync(cancellationToken: stoppingCts.Token);
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         // Stop called without start or there was no consumers registered
         if (receiverTasks.Count == 0) return;
 

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -43,16 +43,12 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
     /// <inheritdoc/>
     protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StartAsync(cancellationToken).ConfigureAwait(false);
-
         await ConnectConsumersAsync(cancellationToken).ConfigureAwait(false);
     }
 
     /// <inheritdoc/>
-    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
+    protected override Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        await base.StopAsync(cancellationToken).ConfigureAwait(false);
-
         var channels = subscriptionChannelsCache.Select(kvp => (key: kvp.Key, sc: kvp.Value)).ToList();
         foreach (var (key, channel) in channels)
         {
@@ -73,6 +69,8 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
                 Logger.LogWarning(exception, "Close channel faulted for {Subscription}", key);
             }
         }
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -41,7 +41,7 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
         : base(serviceScopeFactory, busOptionsAccessor, optionsMonitor, loggerFactory) { }
 
     /// <inheritdoc/>
-    public override async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task StartCoreAsync(CancellationToken cancellationToken)
     {
         await base.StartAsync(cancellationToken).ConfigureAwait(false);
 
@@ -49,7 +49,7 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
     }
 
     /// <inheritdoc/>
-    public override async Task StopAsync(CancellationToken cancellationToken)
+    protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -14,12 +14,6 @@ public class EventBusOptions
     private readonly IList<EventBusTransportRegistrationBuilder> transports = new List<EventBusTransportRegistrationBuilder>();
 
     /// <summary>
-    /// The duration of time to delay the starting of the bus.
-    /// When <see langword="null"/>, the bus is started immediately.
-    /// </summary>
-    public TimeSpan? StartupDelay { get; set; }
-
-    /// <summary>
     /// Gets the <see cref="EventBusNamingOptions"/> for the Event Bus.
     /// </summary>
     public EventBusNamingOptions Naming { get; } = new EventBusNamingOptions();

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -200,33 +200,6 @@ public class EventBus
     ///
     public async Task StartAsync(CancellationToken cancellationToken)
     {
-        // If a startup delay has been specified, apply it
-        var delay = options.StartupDelay;
-        if (delay != null && delay > TimeSpan.Zero)
-        {
-            // With delayed startup, the error may disappear since the call to this method is not awaited.
-            // The appropriate logging needs to be done.
-            try
-            {
-                logger.DelayedBusStartup(delay.Value);
-                await Task.Delay(delay.Value, cancellationToken).ConfigureAwait(false);
-                await StartTransportsAsync(cancellationToken).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-                when (!(ex is OperationCanceledException || ex is TaskCanceledException)) // skip operation cancel
-            {
-                logger.DelayedBusStartupError(ex);
-            }
-        }
-        else
-        {
-            // Without a delay, just start the transports directly
-            await StartTransportsAsync(cancellationToken).ConfigureAwait(false);
-        }
-    }
-
-    private async Task StartTransportsAsync(CancellationToken cancellationToken)
-    {
         // Start the bus and its transports
         logger.StartingBus(transports.Count);
         foreach (var t in transports.Values)

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -86,7 +86,6 @@ public class EventBus
         activity?.AddTag(ActivityTagNames.MessagingConversationId, @event.CorrelationId);
 
         // Publish on the transport
-        logger.SendingEvent(eventBusId: @event.Id, transportName: transport.Name, scheduled: scheduled);
         return await transport.PublishAsync(@event: @event,
                                             registration: reg,
                                             scheduled: scheduled,
@@ -139,7 +138,6 @@ public class EventBus
         activity?.AddTag(ActivityTagNames.MessagingConversationId, string.Join(",", events.Select(e => e.CorrelationId)));
 
         // Publish on the transport
-        logger.SendingEvents(events, transport.Name, scheduled);
         return await transport.PublishAsync(events: events,
                                             registration: reg,
                                             scheduled: scheduled,
@@ -168,7 +166,6 @@ public class EventBus
         activity?.AddTag(ActivityTagNames.MessagingSystem, transport.Name);
 
         // Cancel on the transport
-        logger.CancelingEvent(id, transport.Name);
         await transport.CancelAsync<TEvent>(id: id, registration: reg, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 
@@ -193,7 +190,6 @@ public class EventBus
         activity?.AddTag(ActivityTagNames.MessagingSystem, transport.Name);
 
         // Cancel on the transport
-        logger.CancelingEvents(ids, transport.Name);
         await transport.CancelAsync<TEvent>(ids: ids, registration: reg, cancellationToken: cancellationToken).ConfigureAwait(false);
     }
 

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -207,6 +207,9 @@ public class EventBus
     ///
     public async Task StopAsync(CancellationToken cancellationToken)
     {
+        // Stop the bus
+        logger.StoppingBus();
+
         // Stop the transports in parallel
         logger.StoppingTransports();
         var tasks = transports.Values.Select(t => t.StopAsync(cancellationToken));

--- a/src/Tingle.EventBus/EventBusHost.cs
+++ b/src/Tingle.EventBus/EventBusHost.cs
@@ -40,7 +40,6 @@ internal class EventBusHost : BackgroundService
     /// <inheritdoc/>
     public override async Task StopAsync(CancellationToken cancellationToken)
     {
-        logger.StoppingBus();
         await base.StopAsync(cancellationToken).ConfigureAwait(false);
         await bus.StopAsync(cancellationToken).ConfigureAwait(false);
     }

--- a/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/ILoggerExtensions.cs
@@ -13,19 +13,13 @@ internal static partial class ILoggerExtensions
     [LoggerMessage(101, LogLevel.Debug, "Application did not startup. Event Bus cannot continue.")]
     public static partial void ApplicationDidNotStartup(this ILogger logger);
 
-    [LoggerMessage(102, LogLevel.Information, "Delaying bus startup for '{StartupDelay}'.")]
-    public static partial void DelayedBusStartup(this ILogger logger, TimeSpan startupDelay);
-
-    [LoggerMessage(103, LogLevel.Error, "Starting bus delayed error.")]
-    public static partial void DelayedBusStartupError(this ILogger logger, Exception ex);
-
-    [LoggerMessage(104, LogLevel.Debug, "Starting bus with {TransportsCount} transports.")]
+    [LoggerMessage(102, LogLevel.Debug, "Starting bus with {TransportsCount} transports.")]
     public static partial void StartingBus(this ILogger logger, int transportsCount);
 
-    [LoggerMessage(105, LogLevel.Debug, "Stopping bus.")]
+    [LoggerMessage(103, LogLevel.Debug, "Stopping bus.")]
     public static partial void StoppingBus(this ILogger logger);
 
-    [LoggerMessage(106, LogLevel.Debug, "Stopping transports.")]
+    [LoggerMessage(104, LogLevel.Debug, "Stopping transports.")]
     public static partial void StoppingTransports(this ILogger logger);
 
     #endregion

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -73,7 +73,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
     }
 
     /// <inheritdoc/>
-    public virtual Task StartAsync(CancellationToken cancellationToken)
+    public async Task StartAsync(CancellationToken cancellationToken)
     {
         /*
          * Set the retry policy and unhandled error behaviour if not set.
@@ -93,16 +93,28 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
             }
         }
         Logger.StartingTransport(registrations.Count, Options.EmptyResultsDelay);
+
+        await StartCoreAsync(cancellationToken).ConfigureAwait(false);
+
         startedTcs.TrySetResult(true); // signal completion of startup
-        return Task.CompletedTask;
     }
 
+    /// <summary>Triggered when the bus host is ready to start.</summary>
+    /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+    /// <returns></returns>
+    protected abstract Task StartCoreAsync(CancellationToken cancellationToken);
+
     /// <inheritdoc/>
-    public virtual Task StopAsync(CancellationToken cancellationToken)
+    public async Task StopAsync(CancellationToken cancellationToken)
     {
         Logger.StoppingTransport();
-        return Task.CompletedTask;
+        await StopCoreAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>Triggered when the bus host is performing a graceful shutdown.</summary>
+    /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+    /// <returns></returns>
+    protected abstract Task StopCoreAsync(CancellationToken cancellationToken);
 
     private Task WaitStartedAsync(CancellationToken cancellationToken)
     {

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -153,14 +153,30 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
             ct => PublishCoreAsync(events, registration, scheduled, ct), cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc/>
+    /// <summary>Publish an event on the transport.</summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="event">The event to publish.</param>
+    /// <param name="registration">The registration for the event.</param>
+    /// <param name="scheduled">
+    /// The time at which the event should be availed for consumption.
+    /// Set <see langword="null"/> for immediate availability.
+    /// </param>
+    /// <param name="cancellationToken"></param>
     protected abstract Task<ScheduledResult?> PublishCoreAsync<TEvent>(EventContext<TEvent> @event,
                                                                        EventRegistration registration,
                                                                        DateTimeOffset? scheduled = null,
                                                                        CancellationToken cancellationToken = default)
         where TEvent : class;
 
-    /// <inheritdoc/>
+    /// <summary>Publish a batch of events on the transport.</summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="events">The events to publish.</param>
+    /// <param name="registration">The registration for the events.</param>
+    /// <param name="scheduled">
+    /// The time at which the event should be availed for consumption.
+    /// Set <see langword="null"/> for immediate availability.
+    /// </param>
+    /// <param name="cancellationToken"></param>
     protected abstract Task<IList<ScheduledResult>?> PublishCoreAsync<TEvent>(IList<EventContext<TEvent>> events,
                                                                               EventRegistration registration,
                                                                               DateTimeOffset? scheduled = null,
@@ -169,7 +185,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
 
     #endregion
 
-    #region Cancelling
+    #region Canceling
 
     /// <inheritdoc/>
     public virtual async Task CancelAsync<TEvent>(string id, EventRegistration registration, CancellationToken cancellationToken = default)
@@ -193,13 +209,21 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
             ct => CancelCoreAsync<TEvent>(ids, registration, ct), cancellationToken).ConfigureAwait(false);
     }
 
-    /// <inheritdoc/>
+    /// <summary>Cancel a scheduled event on the transport.</summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="id">The scheduling identifier of the scheduled event.</param>
+    /// <param name="registration">The registration for the event.</param>
+    /// <param name="cancellationToken"></param>
     protected abstract Task CancelCoreAsync<TEvent>(string id,
                                                     EventRegistration registration,
                                                     CancellationToken cancellationToken = default)
         where TEvent : class;
 
-    /// <inheritdoc/>
+    /// <summary>Cancel a batch of scheduled events on the transport.</summary>
+    /// <typeparam name="TEvent">The event type.</typeparam>
+    /// <param name="ids">The scheduling identifiers of the scheduled events.</param>
+    /// <param name="registration">The registration for the events.</param>
+    /// <param name="cancellationToken"></param>
     protected abstract Task CancelCoreAsync<TEvent>(IList<string> ids,
                                                     EventRegistration registration,
                                                     CancellationToken cancellationToken = default)

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -111,6 +111,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // publish, with resilience policies
+        Logger.SendingEvent(eventBusId: @event.Id, transportName: Name, scheduled: scheduled);
         return await registration.ExecutionPolicy.ExecuteAsync(
             ct => PublishCoreAsync(@event, registration, scheduled, ct), cancellationToken).ConfigureAwait(false);
     }
@@ -123,6 +124,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // publish, with resilience policies
+        Logger.SendingEvents(events, Name, scheduled);
         return await registration.ExecutionPolicy.ExecuteAsync(
             ct => PublishCoreAsync(events, registration, scheduled, ct), cancellationToken).ConfigureAwait(false);
     }
@@ -150,6 +152,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // cancel, with resilience policies
+        Logger.CancelingEvent(id, Name);
         await registration.ExecutionPolicy.ExecuteAsync(
             ct => CancelCoreAsync<TEvent>(id, registration, ct), cancellationToken).ConfigureAwait(false);
     }
@@ -159,6 +162,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // cancel, with resilience policies
+        Logger.CancelingEvents(ids, Name);
         await registration.ExecutionPolicy.ExecuteAsync(
             ct => CancelCoreAsync<TEvent>(ids, registration, ct), cancellationToken).ConfigureAwait(false);
     }

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -116,6 +116,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // publish, with resilience policies
+        await WaitStartedAsync(cancellationToken).ConfigureAwait(false);
         Logger.SendingEvent(eventBusId: @event.Id, transportName: Name, scheduled: scheduled);
         return await registration.ExecutionPolicy.ExecuteAsync(
             ct => PublishCoreAsync(@event, registration, scheduled, ct), cancellationToken).ConfigureAwait(false);
@@ -129,6 +130,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // publish, with resilience policies
+        await WaitStartedAsync(cancellationToken).ConfigureAwait(false);
         Logger.SendingEvents(events, Name, scheduled);
         return await registration.ExecutionPolicy.ExecuteAsync(
             ct => PublishCoreAsync(events, registration, scheduled, ct), cancellationToken).ConfigureAwait(false);
@@ -157,6 +159,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // cancel, with resilience policies
+        await WaitStartedAsync(cancellationToken).ConfigureAwait(false);
         Logger.CancelingEvent(id, Name);
         await registration.ExecutionPolicy.ExecuteAsync(
             ct => CancelCoreAsync<TEvent>(id, registration, ct), cancellationToken).ConfigureAwait(false);
@@ -167,6 +170,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         where TEvent : class
     {
         // cancel, with resilience policies
+        await WaitStartedAsync(cancellationToken).ConfigureAwait(false);
         Logger.CancelingEvents(ids, Name);
         await registration.ExecutionPolicy.ExecuteAsync(
             ct => CancelCoreAsync<TEvent>(ids, registration, ct), cancellationToken).ConfigureAwait(false);

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -19,6 +19,8 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
     private readonly IServiceScopeFactory scopeFactory;
     private readonly IOptionsMonitor<TOptions> optionsMonitor;
 
+    private readonly TaskCompletionSource<bool> startedTcs = new(false);
+
     /// <summary>
     /// 
     /// </summary>
@@ -91,6 +93,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
             }
         }
         Logger.StartingTransport(registrations.Count, Options.EmptyResultsDelay);
+        startedTcs.TrySetResult(true);
         return Task.CompletedTask;
     }
 
@@ -100,6 +103,8 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         Logger.StoppingTransport();
         return Task.CompletedTask;
     }
+
+    private Task WaitStartedAsync(CancellationToken cancellationToken) => Task.Run(() => startedTcs.Task, cancellationToken);
 
     #region Publishing
 

--- a/src/Tingle.EventBus/Transports/IEventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/IEventBusTransport.cs
@@ -13,77 +13,59 @@ public interface IEventBusTransport
     /// 
     void Initialize(EventBusTransportRegistration registration);
 
-    /// <summary>
-    /// Triggered when the bus host is ready to start.
-    /// </summary>
+    /// <summary>Triggered when the bus host is ready to start.</summary>
     /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
-    /// <returns></returns>
     Task StartAsync(CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Triggered when the bus host is performing a graceful shutdown.
-    /// </summary>
+    /// <summary>Triggered when the bus host is performing a graceful shutdown.</summary>
     /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
-    /// <returns></returns>
     Task StopAsync(CancellationToken cancellationToken);
 
-    /// <summary>
-    /// Publish an event on the transport.
-    /// </summary>
+    /// <summary>Publish an event on the transport.</summary>
     /// <typeparam name="TEvent">The event type.</typeparam>
     /// <param name="event">The event to publish.</param>
     /// <param name="registration">The registration for the event.</param>
     /// <param name="scheduled">
     /// The time at which the event should be availed for consumption.
-    /// Set null for immediate availability.
+    /// Set <see langword="null"/> for immediate availability.
     /// </param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
     Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event,
                                                 EventRegistration registration,
                                                 DateTimeOffset? scheduled = null,
                                                 CancellationToken cancellationToken = default)
         where TEvent : class;
 
-    /// <summary>
-    /// Publish a batch of events on the transport.
-    /// </summary>
+    /// <summary>Publish a batch of events on the transport.</summary>
     /// <typeparam name="TEvent">The event type.</typeparam>
     /// <param name="events">The events to publish.</param>
     /// <param name="registration">The registration for the events.</param>
     /// <param name="scheduled">
     /// The time at which the event should be availed for consumption.
-    /// Set null for immediate availability.
+    /// Set <see langword="null"/> for immediate availability.
     /// </param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
     Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events,
                                                        EventRegistration registration,
                                                        DateTimeOffset? scheduled = null,
                                                        CancellationToken cancellationToken = default)
         where TEvent : class;
 
-    /// <summary>
-    /// Cancel a scheduled event on the transport.
-    /// </summary>
+    /// <summary>Cancel a scheduled event on the transport.</summary>
     /// <typeparam name="TEvent">The event type.</typeparam>
     /// <param name="id">The scheduling identifier of the scheduled event.</param>
     /// <param name="registration">The registration for the event.</param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
     Task CancelAsync<TEvent>(string id,
                              EventRegistration registration,
                              CancellationToken cancellationToken = default)
         where TEvent : class;
 
-    /// <summary>
-    /// Cancel a batch of scheduled events on the transport.
-    /// </summary>
+    /// <summary>Cancel a batch of scheduled events on the transport.</summary>
     /// <typeparam name="TEvent">The event type.</typeparam>
     /// <param name="ids">The scheduling identifiers of the scheduled events.</param>
     /// <param name="registration">The registration for the events.</param>
     /// <param name="cancellationToken"></param>
-    /// <returns></returns>
     Task CancelAsync<TEvent>(IList<string> ids,
                              EventRegistration registration,
                              CancellationToken cancellationToken = default)


### PR DESCRIPTION
Wait for transport to be ready (using `TaskCompletionSource<bool>`) before calling `PublishCoreAsync(...)` and `CancelAsync(...)` to prevent invalid state of the transport. This particularly happens when events need to be published before the bus and transports are fully ready.

This PR also removes `StartupDelay` to allow configuration issues to be caught early using `BackgroundServiceExceptionBehavior` as described [in the docs](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/hosting-exception-handling)