### PR TITLE
Transports should be created each time especially for different types

### DIFF
--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -90,7 +90,8 @@ public class EventBusBuilder
         if (configureOptions is not null) Services.Configure(name, configureOptions);
 
         Services.ConfigureOptions<TransportOptionsConfigureOptions<TOptions>>();
-        Services.AddSingleton<TTransport>();
+        // //  transport is not registered because multiple separate instances are required per name
+        // Services.AddSingleton<TTransport>();
         return this;
     }
 

--- a/src/Tingle.EventBus/Transports/EventBusTransportProvider.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportProvider.cs
@@ -46,8 +46,14 @@ public sealed class EventBusTransportProvider
             throw new InvalidOperationException($"The transport '{name}' is not registered. Ensure the transport is registered via builder.AddTransport(...)");
         }
 
-        // resolve the transport
-        transport = (IEventBusTransport)serviceProvider.GetRequiredService(tr.TransportType);
+        /*
+         * Create the transport.
+         * 
+         * Do not resolve transports from services because multiple transports of the same type but different names maybe registered.
+         * Resolving the same transport type would result in initialization the same instance, which would be erroneous when started.
+         * Create multiple transports of the same type means each instance can listen to events/messages independently.
+        */
+        transport = (IEventBusTransport)ActivatorUtilities.CreateInstance(serviceProvider, tr.TransportType);
         transport.Initialize(tr); // initialize the transport
         transports.Add(tr.Name, transport);
 


### PR DESCRIPTION
When multiple transports of the same type are registered, each will need to start consuming on its own. When resolved from the service provider, only one instance is created. Instead, a new instance should be created for each registered transport.

This PR solves that and removes registration of transport instances to the IoC container.