### PR TITLE
Fix concurrency issues using ConcurrentDictionary

### DIFF
--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -151,10 +151,7 @@ public class EventBusBuilder
             foreach (var et in eventTypes)
             {
                 // get or create a simple EventRegistration
-                if (!options.Registrations.TryGetValue(et, out var reg))
-                {
-                    reg = options.Registrations[et] = new EventRegistration(et);
-                }
+                var reg = options.Registrations.GetOrAdd(et, t => new EventRegistration(t));
 
                 // create a ConsumerRegistration
                 var ecr = new EventConsumerRegistration(consumerType: consumerType);

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Polly.Retry;
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using Tingle.EventBus;
 using Tingle.EventBus.Configuration;
@@ -82,7 +83,7 @@ public class EventBusOptions
     /// <summary>
     /// The registrations for events and consumers for the EventBus.
     /// </summary>
-    internal Dictionary<Type, EventRegistration> Registrations { get; } = new Dictionary<Type, EventRegistration>();
+    internal ConcurrentDictionary<Type, EventRegistration> Registrations { get; } = new();
 
 
     /// <summary>Adds a <see cref="EventBusTransportRegistration"/>.</summary>
@@ -183,11 +184,7 @@ public class EventBusOptions
 
         // if there's already a registration for the event return it
         var eventType = typeof(TEvent);
-        if (!Registrations.TryGetValue(key: eventType, out var registration))
-        {
-            Registrations[eventType] = registration = new EventRegistration(eventType);
-        }
-
+        var registration = Registrations.GetOrAdd(eventType, et => new EventRegistration(et));
         configure(registration);
 
         return this;

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -234,19 +234,17 @@ public class EventBus
     internal EventRegistration GetOrCreateRegistration<TEvent>()
     {
         // if there's already a registration for the event return it
-        var eventType = typeof(TEvent);
-        if (options.Registrations.TryGetValue(key: eventType, out var registration)) return registration;
-
-        // at this point, the registration does not exist;
-        // create it and add to the registrations for repeated use
-        options.Registrations[eventType] = registration = new EventRegistration(eventType);
-
-        // pass the registration via all the configurators.
-        foreach (var cfg in configurators)
+        return options.Registrations.GetOrAdd(typeof(TEvent), et =>
         {
-            cfg.Configure(registration, options);
-        }
+            // at this point, the registration does not exist;
+            // create it and pass it through all the configurators.
+            var registration = new EventRegistration(et);
+            foreach (var cfg in configurators)
+            {
+                cfg.Configure(registration, options);
+            }
 
-        return registration;
+            return registration;
+        });
     }
 }

--- a/src/Tingle.EventBus/Transports/EventBusTransportProvider.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportProvider.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 
 namespace Tingle.EventBus.Transports;
 
@@ -9,8 +10,8 @@ public sealed class EventBusTransportProvider
     private readonly IServiceProvider serviceProvider;
     private readonly EventBusOptions options;
 
-    private readonly Dictionary<string, EventBusTransportRegistration> registrations = new();
-    private readonly Dictionary<string, IEventBusTransport> transports = new();
+    private readonly IReadOnlyDictionary<string, EventBusTransportRegistration> registrations;
+    private readonly ConcurrentDictionary<string, IEventBusTransport> transports = new();
 
     /// 
     public EventBusTransportProvider(IServiceProvider serviceProvider, IOptions<EventBusOptions> optionsAccessor)
@@ -18,11 +19,13 @@ public sealed class EventBusTransportProvider
         this.serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         options = optionsAccessor?.Value ?? throw new ArgumentNullException(nameof(optionsAccessor));
 
+        var registrations = new Dictionary<string, EventBusTransportRegistration>();
         foreach (var builder in options.Transports)
         {
             var tr = builder.Build();
             registrations.Add(tr.Name, tr);
         }
+        this.registrations = registrations;
     }
 
     ///
@@ -33,30 +36,29 @@ public sealed class EventBusTransportProvider
         var pending = registered.Except(materialized).ToList();
 
         foreach (var name in pending) GetTransport(name);
-        return transports;
+        return new Dictionary<string, IEventBusTransport>(transports.ToArray());
     }
 
     ///
     public IEventBusTransport GetTransport(string name)
     {
-        if (transports.TryGetValue(name, out var transport)) return transport;
-
         if (!registrations.TryGetValue(name, out var tr))
         {
             throw new InvalidOperationException($"The transport '{name}' is not registered. Ensure the transport is registered via builder.AddTransport(...)");
         }
 
-        /*
-         * Create the transport.
-         * 
-         * Do not resolve transports from services because multiple transports of the same type but different names maybe registered.
-         * Resolving the same transport type would result in initialization the same instance, which would be erroneous when started.
-         * Create multiple transports of the same type means each instance can listen to events/messages independently.
-        */
-        transport = (IEventBusTransport)ActivatorUtilities.CreateInstance(serviceProvider, tr.TransportType);
-        transport.Initialize(tr); // initialize the transport
-        transports.Add(tr.Name, transport);
-
-        return transport;
+        return transports.GetOrAdd(name, n =>
+        {
+            /*
+             * Create the transport.
+             * 
+             * Do not resolve transports from services because multiple transports of the same type but different names maybe registered.
+             * Resolving the same transport type would result in initialization the same instance, which would be erroneous when started.
+             * Create multiple transports of the same type means each instance can listen to events/messages independently.
+            */
+            var transport = (IEventBusTransport)ActivatorUtilities.CreateInstance(serviceProvider, tr.TransportType);
+            transport.Initialize(tr); // initialize the transport
+            return transport;
+        });
     }
 }


### PR DESCRIPTION
This PR fixes issues when getting a transport or an `EventRegistration` in the `EventBus` by making use of `ConcurrentDictionary<TKey, TValue>`. This addresses situations where the EventBus would stop functioning because of corrupted data.