### PR TITLE
Hide "pubternal" types

### DIFF
--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -131,7 +131,8 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
             data.CorrelationId = @event.CorrelationId;
         }
 
-        data.Properties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+        data.Properties.ToEventBusWrapper()
+                       .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                        .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                        .AddIfNotDefault(MetadataNames.EventName, registration.EventName)
                        .AddIfNotDefault(MetadataNames.EventType, registration.EventType.FullName)
@@ -185,7 +186,8 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
                 data.CorrelationId = @event.CorrelationId;
             }
 
-            data.Properties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+            data.Properties.ToEventBusWrapper()
+                           .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                            .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                            .AddIfNotDefault(MetadataNames.EventName, registration.EventName)
                            .AddIfNotDefault(MetadataNames.EventType, registration.EventType.FullName)

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -158,7 +158,8 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
         }
 
         // Add custom properties
-        message.ApplicationProperties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+        message.ApplicationProperties.ToEventBusWrapper()
+                                     .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                                      .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                                      .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 
@@ -220,7 +221,8 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
             }
 
             // Add custom properties
-            message.ApplicationProperties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+            message.ApplicationProperties.ToEventBusWrapper()
+                                         .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                                          .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                                          .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -146,7 +146,8 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
         }
 
         // Add custom properties
-        message.Properties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+        message.Properties.ToEventBusWrapper()
+                          .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                           .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                           .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 
@@ -204,7 +205,8 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
             }
 
             // Add custom properties
-            message.Properties.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+            message.Properties.ToEventBusWrapper()
+                              .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                               .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                               .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -126,7 +126,8 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
             }
 
             // Add custom properties
-            properties.Headers.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+            properties.Headers.ToEventBusWrapper()
+                              .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                               .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                               .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 
@@ -202,7 +203,8 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
                 }
 
                 // Add custom properties
-                properties.Headers.AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
+                properties.Headers.ToEventBusWrapper()
+                                  .AddIfNotDefault(MetadataNames.RequestId, @event.RequestId)
                                   .AddIfNotDefault(MetadataNames.InitiatorId, @event.InitiatorId)
                                   .AddIfNotDefault(MetadataNames.ActivityId, Activity.Current?.Id);
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -1,6 +1,7 @@
 ﻿using Tingle.EventBus;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Ids;
+using Tingle.EventBus.Internal;
 using Tingle.EventBus.Serialization;
 using Tingle.EventBus.Transports;
 

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -74,8 +74,9 @@ public class EventBus
         activity?.AddTag(ActivityTagNames.EventBusEventsCount, 1);
 
         // Add diagnostics headers to event
-        @event.Headers.AddIfNotDefault(HeaderNames.EventType, typeof(TEvent).FullName);
-        @event.Headers.AddIfNotDefault(HeaderNames.ActivityId, activity?.Id);
+        @event.Headers.ToEventBusWrapper()
+                      .AddIfNotDefault(HeaderNames.EventType, typeof(TEvent).FullName)
+                      .AddIfNotDefault(HeaderNames.ActivityId, activity?.Id);
 
         // Set properties that may be missing
         @event.Id ??= idGenerator.Generate(reg);
@@ -125,8 +126,9 @@ public class EventBus
         foreach (var @event in events)
         {
             // Add diagnostics headers
-            @event.Headers.AddIfNotDefault(HeaderNames.EventType, typeof(TEvent).FullName);
-            @event.Headers.AddIfNotDefault(HeaderNames.ActivityId, Activity.Current?.Id);
+            @event.Headers.ToEventBusWrapper()
+                          .AddIfNotDefault(HeaderNames.EventType, typeof(TEvent).FullName)
+                          .AddIfNotDefault(HeaderNames.ActivityId, Activity.Current?.Id);
 
             // Set properties that may be missing
             @event.Id ??= idGenerator.Generate(reg);

--- a/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
@@ -1,31 +1,18 @@
-﻿namespace System.Collections.Generic;
+﻿using Tingle.EventBus;
 
-/// <summary>
-/// Extension methods on <see cref="IDictionary{TKey, TValue}"/>
-/// </summary>
+namespace System.Collections.Generic;
+
+/// <summary>Extension methods on <see cref="IDictionary{TKey, TValue}"/>.</summary>
 public static class DictionaryExtensions
 {
     /// <summary>
-    /// Adds an element with the provided key and value to the <see cref="IDictionary{TKey, TValue}"/>,
-    /// provided the value is not equal to the type's default value (or empty for strings).
+    /// Creates an <see cref="EventBusDictionaryWrapper{TKey, TValue}"/>
+    /// wrapping around the provided <see cref="IDictionary{TKey, TValue}"/>.
     /// </summary>
     /// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
     /// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
     /// <param name="dictionary">The dictionary to use</param>
-    /// <param name="key">The object to use as the key of the element to add.</param>
-    /// <param name="value">The object to use as the value of the element to add.</param>
-    /// <exception cref="ArgumentNullException">key is null.</exception>
-    /// <exception cref="ArgumentException">An element with the same key already exists in the <see cref="IDictionary{TKey, TValue}"/>.</exception>
-    /// <exception cref="NotSupportedException">The <see cref="IDictionary{TKey, TValue}"/> is read-only.</exception>
     /// <returns></returns>
-    public static IDictionary<TKey, TValue> AddIfNotDefault<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue? value)
-        where TKey : notnull
-    {
-        if (value is not null || (value is string s && !string.IsNullOrWhiteSpace(s)))
-        {
-            dictionary[key] = value;
-        }
-
-        return dictionary;
-    }
+    public static EventBusDictionaryWrapper<TKey, TValue> ToEventBusWrapper<TKey, TValue>(this IDictionary<TKey, TValue> dictionary)
+        where TKey : notnull => new(dictionary);
 }

--- a/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
+++ b/src/Tingle.EventBus/Extensions/DictionaryExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Tingle.EventBus;
+﻿using Tingle.EventBus.Internal;
 
 namespace System.Collections.Generic;
 

--- a/src/Tingle.EventBus/Internal/EventBusDictionaryWrapper.cs
+++ b/src/Tingle.EventBus/Internal/EventBusDictionaryWrapper.cs
@@ -1,0 +1,51 @@
+﻿namespace Tingle.EventBus.Internal;
+
+/// <summary>A wrapper around <see cref="IDictionary{TKey, TValue}"/> for EventBus related functionality.</summary>
+/// <remarks>
+/// This type exists instead of extension methods so that it is exposed to other projects/packages in the Tingle.EventBus group
+/// while discouraging external projects/packages/application from using the methods
+/// </remarks>
+public sealed class EventBusDictionaryWrapper<TKey, TValue> where TKey : notnull
+{
+    private readonly IDictionary<TKey, TValue> dictionary;
+
+    /// <summary>Creates an instance of <see cref="EventBusDictionaryWrapper{TKey, TValue}"/>.</summary>
+    public EventBusDictionaryWrapper() : this(new Dictionary<TKey, TValue>()) { }
+
+    /// <summary>Creates an instance of <see cref="EventBusDictionaryWrapper{TKey, TValue}"/>.</summary>
+    /// <param name="dictionary">The <see cref="IDictionary{TKey, TValue}"/> to use.</param>
+    /// <exception cref="ArgumentException">dictionary is read-only.</exception>
+    /// <exception cref="ArgumentNullException">dictionary is null.</exception>
+    public EventBusDictionaryWrapper(IDictionary<TKey, TValue> dictionary)
+    {
+        if (dictionary.IsReadOnly)
+        {
+            throw new ArgumentException("Read-only dictionaries are not allowed.", nameof(dictionary));
+        }
+
+        this.dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+    }
+
+    /// <summary>The dictionary managed.</summary>
+    public IDictionary<TKey, TValue> Dictionary => dictionary;
+
+    /// <summary>
+    /// Adds an element with the provided key and value,
+    /// provided the value is not equal to the type's default value (or empty for strings).
+    /// </summary>
+    /// <param name="key">The object to use as the key of the element to add.</param>
+    /// <param name="value">The object to use as the value of the element to add.</param>
+    /// <exception cref="ArgumentNullException">key is null.</exception>
+    /// <exception cref="ArgumentException">An element with the same key already exists in the dictionary.</exception>
+    /// <exception cref="NotSupportedException">The dictionary is read-only.</exception>
+    /// <returns></returns>
+    public EventBusDictionaryWrapper<TKey, TValue> AddIfNotDefault(TKey key, TValue? value)
+    {
+        if (value is not null || value is string s && !string.IsNullOrWhiteSpace(s))
+        {
+            dictionary[key] = value;
+        }
+
+        return this;
+    }
+}

--- a/src/Tingle.EventBus/Internal/EventBusHost.cs
+++ b/src/Tingle.EventBus/Internal/EventBusHost.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
-namespace Tingle.EventBus;
+namespace Tingle.EventBus.Internal;
 
 /// <summary>
 /// Host for <see cref="EventBus"/>.

--- a/src/Tingle.EventBus/Internal/PollyHelper.cs
+++ b/src/Tingle.EventBus/Internal/PollyHelper.cs
@@ -3,7 +3,7 @@ using Polly;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Transports;
 
-namespace Tingle.EventBus;
+namespace Tingle.EventBus.Internal;
 
 internal static class PollyHelper
 {

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -5,6 +5,7 @@ using System.Net.Mime;
 using System.Text.RegularExpressions;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Diagnostics;
+using Tingle.EventBus.Internal;
 using Tingle.EventBus.Serialization;
 
 namespace Tingle.EventBus.Transports;

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -412,22 +412,24 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
                                                        string? sequenceNumber = null,
                                                        IDictionary<string, string?>? extras = null)
     {
-        var state = new EventBusDictionaryWrapper<string, string>();
-        state.AddIfNotDefault(MetadataNames.Id, id);
-        state.AddIfNotDefault(MetadataNames.CorrelationId, correlationId);
-        state.AddIfNotDefault(MetadataNames.SequenceNumber, sequenceNumber);
+        var state = new Dictionary<string, string>();
+        state.ToEventBusWrapper()
+             .AddIfNotDefault(MetadataNames.Id, id)
+             .AddIfNotDefault(MetadataNames.CorrelationId, correlationId)
+             .AddIfNotDefault(MetadataNames.SequenceNumber, sequenceNumber);
 
         // if there are extras, add them
         if (extras != null)
         {
+            var wr = state.ToEventBusWrapper();
             foreach (var kvp in extras)
             {
-                state.AddIfNotDefault(kvp.Key, kvp.Value);
+                wr.AddIfNotDefault(kvp.Key, kvp.Value);
             }
         }
 
         // create the scope
-        return Logger.BeginScope(state.Dictionary);
+        return Logger.BeginScope(state);
     }
 
     #endregion

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -412,7 +412,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
                                                        string? sequenceNumber = null,
                                                        IDictionary<string, string?>? extras = null)
     {
-        var state = new Dictionary<string, string>();
+        var state = new EventBusDictionaryWrapper<string, string>();
         state.AddIfNotDefault(MetadataNames.Id, id);
         state.AddIfNotDefault(MetadataNames.CorrelationId, correlationId);
         state.AddIfNotDefault(MetadataNames.SequenceNumber, sequenceNumber);
@@ -427,7 +427,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         }
 
         // create the scope
-        return Logger.BeginScope(state);
+        return Logger.BeginScope(state.Dictionary);
     }
 
     #endregion


### PR DESCRIPTION
Hide public types that should be internal but may be needed by other packages/projects in an `Internal` namespace/folder.