### PR TITLE
Custom ConcurrentDictionary<TKey, TValue> for transports

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -20,8 +20,8 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs;
 /// </summary>
 public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, IDisposable
 {
-    private readonly EventBusConcurrentDictionary<Type, string> topicArnsCache = new(1, 1);
-    private readonly EventBusConcurrentDictionary<QueueCacheKey, string> queueUrlsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<Type, string> topicArnsCache = new();
+    private readonly EventBusConcurrentDictionary<QueueCacheKey, string> queueUrlsCache = new();
     private readonly CancellationTokenSource stoppingCts = new();
     private readonly List<Task> receiverTasks = new();
     private readonly Lazy<AmazonSimpleNotificationServiceClient> snsClient;

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Net.Mime;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Diagnostics;
+using Tingle.EventBus.Internal;
 
 namespace Tingle.EventBus.Transports.Amazon.Sqs;
 
@@ -19,10 +20,8 @@ namespace Tingle.EventBus.Transports.Amazon.Sqs;
 /// </summary>
 public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, IDisposable
 {
-    private readonly Dictionary<Type, string> topicArnsCache = new();
-    private readonly SemaphoreSlim topicArnsCacheLock = new(1, 1); // only one at a time.
-    private readonly Dictionary<QueueCacheKey, string> queueUrlsCache = new();
-    private readonly SemaphoreSlim queueUrlsCacheLock = new(1, 1); // only one at a time.
+    private readonly EventBusConcurrentDictionary<Type, string> topicArnsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<QueueCacheKey, string> queueUrlsCache = new(1, 1);
     private readonly CancellationTokenSource stoppingCts = new();
     private readonly List<Task> receiverTasks = new();
     private readonly Lazy<AmazonSimpleNotificationServiceClient> snsClient;
@@ -256,60 +255,30 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
         throw new NotSupportedException("Amazon SNS does not support canceling published messages.");
     }
 
-    private async Task<string> GetTopicArnAsync(EventRegistration reg, CancellationToken cancellationToken)
+    private Task<string> GetTopicArnAsync(EventRegistration reg, CancellationToken cancellationToken)
+        => topicArnsCache.GetOrAddAsync(reg.EventType, (_, ct) => CreateTopicIfNotExistsAsync(topicName: reg.EventName!, reg: reg, cancellationToken: ct), cancellationToken);
+
+    private Task<string> GetQueueUrlAsync(EventRegistration reg, EventConsumerRegistration? ecr = null, bool deadletter = false, CancellationToken cancellationToken = default)
     {
-        await topicArnsCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        var key = CreateQueueCacheKey(reg, ecr, deadletter);
+        return queueUrlsCache.GetOrAddAsync(key, async (_, ct) =>
         {
-            if (!topicArnsCache.TryGetValue(reg.EventType, out var topicArn))
+            // ensure queue is created before creating subscription
+            var queueUrl = await CreateQueueIfNotExistsAsync(queueName: key.Name, reg: reg, ecr: ecr, cancellationToken: ct).ConfigureAwait(false);
+
+            // for non dead-letter broadcast types, we need to ensure the topic exists and the queue is subscribed to it
+            if (!deadletter && reg.EntityKind == EntityKind.Broadcast)
             {
-                // ensure topic is created, then add it's arn to the cache
-                var name = reg.EventName!;
-                topicArn = await CreateTopicIfNotExistsAsync(topicName: name, reg: reg, cancellationToken: cancellationToken).ConfigureAwait(false);
-                topicArnsCache[reg.EventType] = topicArn;
-            }
+                // ensure topic is created before creating the subscription
+                var topicName = reg.EventName!;
+                var topicArn = await CreateTopicIfNotExistsAsync(topicName: topicName, reg: reg, cancellationToken: ct).ConfigureAwait(false);
 
-            return topicArn;
-        }
-        finally
-        {
-            topicArnsCacheLock.Release();
-        }
-    }
-
-    private async Task<string> GetQueueUrlAsync(EventRegistration reg, EventConsumerRegistration? ecr = null, bool deadletter = false, CancellationToken cancellationToken = default)
-    {
-        await queueUrlsCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
-        {
-            var key = CreateQueueCacheKey(reg, ecr, deadletter);
-            if (!queueUrlsCache.TryGetValue(key, out var queueUrl))
-            {
-                // ensure queue is created before creating subscription
-                queueUrl = await CreateQueueIfNotExistsAsync(queueName: key.Name, reg: reg, ecr: ecr, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                // for non dead-letter broadcast types, we need to ensure the topic exists and the queue is subscribed to it
-                if (!deadletter && reg.EntityKind == EntityKind.Broadcast)
-                {
-                    // ensure topic is created before creating the subscription
-                    var topicName = reg.EventName!;
-                    var topicArn = await CreateTopicIfNotExistsAsync(topicName: topicName, reg: reg, cancellationToken: cancellationToken).ConfigureAwait(false);
-
-                    // create subscription from the topic to the queue
-                    await snsClient.Value.SubscribeQueueAsync(topicArn: topicArn, sqsClient.Value, queueUrl).ConfigureAwait(false);
-                }
-
-                queueUrlsCache[key] = queueUrl;
+                // create subscription from the topic to the queue
+                await snsClient.Value.SubscribeQueueAsync(topicArn: topicArn, sqsClient.Value, queueUrl).ConfigureAwait(false);
             }
 
             return queueUrl;
-        }
-        finally
-        {
-            queueUrlsCacheLock.Release();
-        }
+        }, cancellationToken);
     }
 
     record QueueCacheKey

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -19,8 +19,8 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs;
 /// </summary>
 public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransportOptions>
 {
-    private readonly EventBusConcurrentDictionary<(Type, bool), EventHubProducerClient> producersCache = new(1, 1);
-    private readonly EventBusConcurrentDictionary<string, EventProcessorClient> processorsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<(Type, bool), EventHubProducerClient> producersCache = new();
+    private readonly EventBusConcurrentDictionary<string, EventProcessorClient> processorsCache = new();
 
     /// <summary>
     /// 

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Net.Mime;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Diagnostics;
+using Tingle.EventBus.Internal;
 
 namespace Tingle.EventBus.Transports.Azure.EventHubs;
 
@@ -18,10 +19,8 @@ namespace Tingle.EventBus.Transports.Azure.EventHubs;
 /// </summary>
 public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransportOptions>
 {
-    private readonly Dictionary<(Type, bool), EventHubProducerClient> producersCache = new();
-    private readonly SemaphoreSlim producersCacheLock = new(1, 1); // only one at a time.
-    private readonly Dictionary<string, EventProcessorClient> processorsCache = new();
-    private readonly SemaphoreSlim processorsCacheLock = new(1, 1); // only one at a time.
+    private readonly EventBusConcurrentDictionary<(Type, bool), EventHubProducerClient> producersCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<string, EventProcessorClient> processorsCache = new(1, 1);
 
     /// <summary>
     /// 
@@ -77,14 +76,15 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
         var clients = processorsCache.Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
-        foreach (var (key, proc) in clients)
+        foreach (var (key, t) in clients)
         {
             Logger.StoppingProcessor(processor: key);
 
             try
             {
+                var proc = await t.ConfigureAwait(false);
                 await proc.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
-                processorsCache.Remove(key);
+                processorsCache.TryRemove(key, out _);
 
                 Logger.StoppedProcessor(processor: key);
             }
@@ -220,112 +220,97 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
         throw new NotSupportedException("Azure EventHubs does not support canceling published events.");
     }
 
-    private async Task<EventHubProducerClient> GetProducerAsync(EventRegistration reg, bool deadletter, CancellationToken cancellationToken)
+    private Task<EventHubProducerClient> GetProducerAsync(EventRegistration reg, bool deadletter, CancellationToken cancellationToken)
     {
-        await producersCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        Task<EventHubProducerClient> creator((Type, bool) _, CancellationToken ct)
         {
-            if (!producersCache.TryGetValue((reg.EventType, deadletter), out var producer))
+            var name = reg.EventName;
+            if (deadletter) name += Options.DeadLetterSuffix;
+
+            // Create the producer options
+            var epco = new EventHubProducerClientOptions
             {
-                var name = reg.EventName;
-                if (deadletter) name += Options.DeadLetterSuffix;
-
-                // Create the producer options
-                var epco = new EventHubProducerClientOptions
+                ConnectionOptions = new EventHubConnectionOptions
                 {
-                    ConnectionOptions = new EventHubConnectionOptions
-                    {
-                        TransportType = Options.TransportType,
-                    },
-                };
+                    TransportType = Options.TransportType,
+                },
+            };
 
-                // Allow for the defaults to be overridden
-                Options.SetupProducerClientOptions?.Invoke(reg, epco);
+            // Allow for the defaults to be overridden
+            Options.SetupProducerClientOptions?.Invoke(reg, epco);
 
-                // Override values that must be overridden
+            // Override values that must be overridden
 
-                // Create the producer client
-                var cred = Options.Credentials.CurrentValue;
-                producer = cred is AzureEventHubsTransportCredentials aehtc
-                        ? new EventHubProducerClient(fullyQualifiedNamespace: aehtc.FullyQualifiedNamespace,
-                                                     eventHubName: name,
-                                                     credential: aehtc.TokenCredential,
-                                                     clientOptions: epco)
-                        : new EventHubProducerClient(connectionString: (string)cred,
-                                                     eventHubName: name,
-                                                     clientOptions: epco);
+            // Create the producer client
+            var cred = Options.Credentials.CurrentValue;
+            var producer = cred is AzureEventHubsTransportCredentials aehtc
+                    ? new EventHubProducerClient(fullyQualifiedNamespace: aehtc.FullyQualifiedNamespace,
+                                                 eventHubName: name,
+                                                 credential: aehtc.TokenCredential,
+                                                 clientOptions: epco)
+                    : new EventHubProducerClient(connectionString: (string)cred,
+                                                 eventHubName: name,
+                                                 clientOptions: epco);
 
-                // How to ensure event hub is created?
-                // EventHubs can only be create via Azure portal or using Resource Manager which need different credentials
+            // How to ensure event hub is created?
+            // EventHubs can only be create via Azure portal or using Resource Manager which need different credentials
 
-                producersCache[(reg.EventType, deadletter)] = producer;
-            }
-
-            return producer;
+            return Task.FromResult(producer);
         }
-        finally
-        {
-            producersCacheLock.Release();
-        }
+        return producersCache.GetOrAddAsync((reg.EventType, deadletter), creator, cancellationToken);
     }
 
-    private async Task<EventProcessorClient> GetProcessorAsync(EventRegistration reg, EventConsumerRegistration ecr, CancellationToken cancellationToken)
+    private Task<EventProcessorClient> GetProcessorAsync(EventRegistration reg, EventConsumerRegistration ecr, CancellationToken cancellationToken)
     {
-        await processorsCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        // For events configured as sourced from IoT Hub,
+        // 1. The event hub name is in the metadata
+        // 2. The ConsumerGroup is set to $Default (this may be changed to support more)
+        var isIotHub = reg.IsConfiguredAsIotHub();
+        var eventHubName = isIotHub ? reg.GetIotHubEventHubName() : reg.EventName;
+        var consumerGroup = isIotHub || Options.UseBasicTier ? EventHubConsumerClient.DefaultConsumerGroupName : ecr.ConsumerName;
 
-        try
+        Task<EventProcessorClient> creator(string key, CancellationToken ct)
         {
-            // For events configured as sourced from IoT Hub,
-            // 1. The event hub name is in the metadata
-            // 2. The ConsumerGroup is set to $Default (this may be changed to support more)
-            var isIotHub = reg.IsConfiguredAsIotHub();
-            var eventHubName = isIotHub ? reg.GetIotHubEventHubName() : reg.EventName;
-            var consumerGroup = isIotHub || Options.UseBasicTier ? EventHubConsumerClient.DefaultConsumerGroupName : ecr.ConsumerName;
+            // if the EventHub or consumer group does not exist, create it
 
-            var key = $"{eventHubName}/{consumerGroup}";
-            if (!processorsCache.TryGetValue(key, out var processor))
+            /*
+             * The publish/subscribe mechanism of Event Hubs is enabled through consumer groups.
+             * A consumer group is a view (state, position, or offset) of an entire event hub.
+             * Consumer groups enable multiple consuming applications to each have a separate view
+             * of the event stream, and to read the stream independently at their own pace and with
+             * their own offsets.
+             * 
+             * EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager
+             * which needs different credentials.
+             */
+
+            // blobContainerUri has the format "https://{account_name}.blob.core.windows.net/{container_name}" which can be made using "{BlobServiceUri}/{container_name}".
+            var cred_bs = Options.BlobStorageCredentials.CurrentValue;
+            var blobContainerClient = cred_bs is AzureBlobStorageCredentials abstc
+                ? new BlobContainerClient(blobContainerUri: new Uri($"{abstc.BlobServiceUrl}/{Options.BlobContainerName}"),
+                                          credential: abstc.TokenCredential)
+                : new BlobContainerClient(connectionString: (string)cred_bs,
+                                          blobContainerName: Options.BlobContainerName);
+
+            // Create the processor client options
+            var epco = new EventProcessorClientOptions
             {
-                // if the EventHub or consumer group does not exist, create it
-
-                /*
-                 * The publish/subscribe mechanism of Event Hubs is enabled through consumer groups.
-                 * A consumer group is a view (state, position, or offset) of an entire event hub.
-                 * Consumer groups enable multiple consuming applications to each have a separate view
-                 * of the event stream, and to read the stream independently at their own pace and with
-                 * their own offsets.
-                 * 
-                 * EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager
-                 * which needs different credentials.
-                 */
-
-                // blobContainerUri has the format "https://{account_name}.blob.core.windows.net/{container_name}" which can be made using "{BlobServiceUri}/{container_name}".
-                var cred_bs = Options.BlobStorageCredentials.CurrentValue;
-                var blobContainerClient = cred_bs is AzureBlobStorageCredentials abstc
-                    ? new BlobContainerClient(blobContainerUri: new Uri($"{abstc.BlobServiceUrl}/{Options.BlobContainerName}"),
-                                              credential: abstc.TokenCredential)
-                    : new BlobContainerClient(connectionString: (string)cred_bs,
-                                              blobContainerName: Options.BlobContainerName);
-
-                // Create the processor client options
-                var epco = new EventProcessorClientOptions
+                ConnectionOptions = new EventHubConnectionOptions
                 {
-                    ConnectionOptions = new EventHubConnectionOptions
-                    {
-                        TransportType = Options.TransportType,
-                    },
-                };
+                    TransportType = Options.TransportType,
+                },
+            };
 
-                // Allow for the defaults to be overridden
-                Options.SetupProcessorClientOptions?.Invoke(reg, ecr, epco);
+            // Allow for the defaults to be overridden
+            Options.SetupProcessorClientOptions?.Invoke(reg, ecr, epco);
 
-                // How to ensure consumer is created in the event hub?
-                // EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager which need different credentials
+            // How to ensure consumer is created in the event hub?
+            // EventHubs and ConsumerGroups can only be create via Azure portal or using Resource Manager which need different credentials
 
 
-                // Create the processor client
-                var cred = Options.Credentials.CurrentValue;
-                processor = cred is AzureEventHubsTransportCredentials aehtc
+            // Create the processor client
+            var cred = Options.Credentials.CurrentValue;
+            var processor = cred is AzureEventHubsTransportCredentials aehtc
                     ? new EventProcessorClient(checkpointStore: blobContainerClient,
                                                consumerGroup: consumerGroup,
                                                fullyQualifiedNamespace: aehtc.FullyQualifiedNamespace,
@@ -338,15 +323,11 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
                                                eventHubName: eventHubName,
                                                clientOptions: epco);
 
-                processorsCache[key] = processor;
-            }
+            return Task.FromResult(processor);
+        }
 
-            return processor;
-        }
-        finally
-        {
-            processorsCacheLock.Release();
-        }
+        var key = $"{eventHubName}/{consumerGroup}";
+        return processorsCache.GetOrAddAsync(key, creator, cancellationToken);
     }
 
     private async Task OnEventReceivedAsync<TEvent, TConsumer>(EventRegistration reg,

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -15,7 +15,7 @@ namespace Tingle.EventBus.Transports.Azure.QueueStorage;
 /// </summary>
 public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTransportOptions>, IDisposable
 {
-    private readonly EventBusConcurrentDictionary<(Type, bool), QueueClient> queueClientsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<(Type, bool), QueueClient> queueClientsCache = new();
     private readonly CancellationTokenSource stoppingCts = new();
     private readonly List<Task> receiverTasks = new();
     private readonly Lazy<QueueServiceClient> serviceClient;

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -16,8 +16,8 @@ namespace Tingle.EventBus.Transports.Azure.ServiceBus;
 /// </summary>
 public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTransportOptions>
 {
-    private readonly EventBusConcurrentDictionary<Type, ServiceBusSender> sendersCache = new(1, 1);
-    private readonly EventBusConcurrentDictionary<string, ServiceBusProcessor> processorsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<Type, ServiceBusSender> sendersCache = new();
+    private readonly EventBusConcurrentDictionary<string, ServiceBusProcessor> processorsCache = new();
     private readonly SemaphoreSlim propertiesCacheLock = new(1, 1); // only one at a time.
     private readonly Lazy<ServiceBusAdministrationClient> managementClient;
     private readonly Lazy<ServiceBusClient> serviceBusClient;

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Net.Mime;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Diagnostics;
+using Tingle.EventBus.Internal;
 using Tingle.EventBus.Transports.InMemory.Client;
 
 namespace Tingle.EventBus.Transports.InMemory;
@@ -16,10 +17,8 @@ namespace Tingle.EventBus.Transports.InMemory;
 /// </summary>
 public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
 {
-    private readonly Dictionary<Type, InMemorySender> sendersCache = new();
-    private readonly SemaphoreSlim sendersCacheLock = new(1, 1); // only one at a time.
-    private readonly Dictionary<string, InMemoryProcessor> processorsCache = new();
-    private readonly SemaphoreSlim processorsCacheLock = new(1, 1); // only one at a time.
+    private readonly EventBusConcurrentDictionary<Type, InMemorySender> sendersCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<string, InMemoryProcessor> processorsCache = new(1, 1);
     private readonly InMemoryClient inMemoryClient;
 
     private readonly ConcurrentBag<EventContext> published = new();
@@ -95,15 +94,16 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
     /// <inheritdoc/>
     protected override async Task StopCoreAsync(CancellationToken cancellationToken)
     {
-        var clients = processorsCache.Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
-        foreach (var (key, proc) in clients)
+        var clients = processorsCache.ToArray().Select(kvp => (key: kvp.Key, proc: kvp.Value)).ToList();
+        foreach (var (key, t) in clients)
         {
             Logger.StoppingProcessor(processor: key);
 
             try
             {
+                var proc = await t.ConfigureAwait(false);
                 await proc.StopProcessingAsync(cancellationToken).ConfigureAwait(false);
-                processorsCache.Remove(key);
+                processorsCache.TryRemove(key, out _);
 
                 Logger.StoppedProcessor(processor: key);
             }
@@ -280,68 +280,45 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
         AddBatch(cancelled, seqNums);
     }
 
-    private async Task<InMemorySender> GetSenderAsync(EventRegistration reg, CancellationToken cancellationToken)
+    private Task<InMemorySender> GetSenderAsync(EventRegistration reg, CancellationToken cancellationToken)
     {
-        await sendersCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
-
-        try
+        Task<InMemorySender> creator(Type _, CancellationToken ct)
         {
-            if (!sendersCache.TryGetValue(reg.EventType, out var sender))
-            {
-                // Create the sender
-                var name = reg.EventName!;
-                sender = inMemoryClient.CreateSender(name: name, broadcast: reg.EntityKind == EntityKind.Broadcast);
-                sendersCache[reg.EventType] = sender;
-            }
-
-            return sender;
+            var sender = inMemoryClient.CreateSender(name: reg.EventName!, broadcast: reg.EntityKind == EntityKind.Broadcast);
+            return Task.FromResult(sender);
         }
-        finally
-        {
-            sendersCacheLock.Release();
-        }
+        return sendersCache.GetOrAddAsync(reg.EventType, creator, cancellationToken);
     }
 
-    private async Task<InMemoryProcessor> GetProcessorAsync(EventRegistration reg, EventConsumerRegistration ecr, CancellationToken cancellationToken)
+    private Task<InMemoryProcessor> GetProcessorAsync(EventRegistration reg, EventConsumerRegistration ecr, CancellationToken cancellationToken)
     {
-        await processorsCacheLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        var topicName = reg.EventName!;
+        var subscriptionName = ecr.ConsumerName!;
 
-        try
+        var key = $"{topicName}/{subscriptionName}";
+        Task<InMemoryProcessor> creator(string _, CancellationToken ct)
         {
-            var topicName = reg.EventName!;
-            var subscriptionName = ecr.ConsumerName!;
+            // Create the processor options
+            var inpo = new InMemoryProcessorOptions { };
 
-            var key = $"{topicName}/{subscriptionName}";
-            if (!processorsCache.TryGetValue(key, out var processor))
+            // Create the processor.
+            InMemoryProcessor processor;
+            if (reg.EntityKind == EntityKind.Queue)
             {
-                // Create the processor options
-                var inpo = new InMemoryProcessorOptions { };
-
-                // Create the processor.
-                if (reg.EntityKind == EntityKind.Queue)
-                {
-                    // Create the processor for the Queue
-                    Logger.CreatingQueueProcessor(queueName: topicName);
-                    processor = inMemoryClient.CreateProcessor(queueName: topicName, options: inpo);
-                }
-                else
-                {
-                    // Create the processor for the Subscription
-                    Logger.CreatingSubscriptionProcessor(topicName: topicName, subscriptionName: subscriptionName);
-                    processor = inMemoryClient.CreateProcessor(topicName: topicName,
-                                                               subscriptionName: subscriptionName,
-                                                               options: inpo);
-                }
-
-                processorsCache[key] = processor;
+                // Create the processor for the Queue
+                Logger.CreatingQueueProcessor(queueName: topicName);
+                processor = inMemoryClient.CreateProcessor(queueName: topicName, options: inpo);
+            }
+            else
+            {
+                // Create the processor for the Subscription
+                Logger.CreatingSubscriptionProcessor(topicName: topicName, subscriptionName: subscriptionName);
+                processor = inMemoryClient.CreateProcessor(topicName: topicName, subscriptionName: subscriptionName, options: inpo);
             }
 
-            return processor;
+            return Task.FromResult(processor);
         }
-        finally
-        {
-            processorsCacheLock.Release();
-        }
+        return processorsCache.GetOrAddAsync(key, creator, cancellationToken);
     }
 
     private async Task OnMessageReceivedAsync<TEvent, TConsumer>(EventRegistration reg,

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -17,8 +17,8 @@ namespace Tingle.EventBus.Transports.InMemory;
 /// </summary>
 public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
 {
-    private readonly EventBusConcurrentDictionary<Type, InMemorySender> sendersCache = new(1, 1);
-    private readonly EventBusConcurrentDictionary<string, InMemoryProcessor> processorsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<Type, InMemorySender> sendersCache = new();
+    private readonly EventBusConcurrentDictionary<string, InMemoryProcessor> processorsCache = new();
     private readonly InMemoryClient inMemoryClient;
 
     private readonly ConcurrentBag<EventContext> published = new();

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -21,7 +21,7 @@ namespace Tingle.EventBus.Transports.RabbitMQ;
 public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, IDisposable
 {
     private readonly SemaphoreSlim connectionLock = new(1, 1);
-    private readonly EventBusConcurrentDictionary<string, IModel> subscriptionChannelsCache = new(1, 1);
+    private readonly EventBusConcurrentDictionary<string, IModel> subscriptionChannelsCache = new();
     private RetryPolicy? retryPolicy;
 
     private IConnection? connection;

--- a/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
+++ b/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
@@ -12,30 +12,6 @@ namespace Tingle.EventBus.Internal;
 [DefaultMember("Item")]
 public sealed class EventBusConcurrentDictionary<TKey, TValue> : ConcurrentDictionary<TKey, Task<TValue>> where TKey : notnull
 {
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary() { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection) : base(collection) { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(IEqualityComparer<TKey>? comparer) : base(comparer) { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection, IEqualityComparer<TKey>? comparer)
-        : base(collection, comparer) { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(int concurrencyLevel, int capacity) : base(concurrencyLevel, capacity) { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(int concurrencyLevel, IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection, IEqualityComparer<TKey>? comparer)
-        : base(concurrencyLevel, collection, comparer) { }
-
-    /// <inheritdoc/>
-    public EventBusConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey>? comparer)
-        : base(concurrencyLevel, capacity, comparer) { }
-
     // Code below is inspired by https://gist.github.com/davidfowl/3dac8f7b3d141ae87abf770d5781feed#file-concurrentdictionaryextensions-cs-L53-L87
 
     /// <summary>

--- a/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
+++ b/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
@@ -12,6 +12,18 @@ namespace Tingle.EventBus.Internal;
 [DefaultMember("Item")]
 public sealed class EventBusConcurrentDictionary<TKey, TValue> : ConcurrentDictionary<TKey, Task<TValue>> where TKey : notnull
 {
+    /// <inheritdoc/>
+    [Obsolete("Use '" + nameof(GetOrAddAsync) + "(...)' instead")]
+    public new Task<TValue> GetOrAdd(TKey key, Task<TValue> value) => base.GetOrAdd(key, value);
+
+    /// <inheritdoc/>
+    [Obsolete("Use '" + nameof(GetOrAddAsync) + "(...)' instead")]
+    public new Task<TValue> GetOrAdd(TKey key, Func<TKey, Task<TValue>> valueFactory) => base.GetOrAdd(key, valueFactory);
+
+    /// <inheritdoc/>
+    [Obsolete("Use '" + nameof(GetOrAddAsync) + "(...)' instead")]
+    public new Task<TValue> GetOrAdd<TArg>(TKey key, Func<TKey, TArg, Task<TValue>> valueFactory, TArg factoryArgument) => base.GetOrAdd(key, valueFactory, factoryArgument);
+
     // Code below is inspired by https://gist.github.com/davidfowl/3dac8f7b3d141ae87abf770d5781feed#file-concurrentdictionaryextensions-cs-L53-L87
 
     /// <summary>

--- a/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
+++ b/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Tingle.EventBus.Internal;
+
+/// <summary>
+/// Represents a thread-safe collection of key/value pairs that can be accessed by
+/// multiple threads in the EventBus asynchronously.
+/// </summary>
+/// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+[DefaultMember("Item")]
+public sealed class EventBusConcurrentDictionary<TKey, TValue> : ConcurrentDictionary<TKey, Task<TValue>> where TKey : notnull
+{
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary() { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection) : base(collection) { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(IEqualityComparer<TKey>? comparer) : base(comparer) { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection, IEqualityComparer<TKey>? comparer)
+        : base(collection, comparer) { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(int concurrencyLevel, int capacity) : base(concurrencyLevel, capacity) { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(int concurrencyLevel, IEnumerable<KeyValuePair<TKey, Task<TValue>>> collection, IEqualityComparer<TKey>? comparer)
+        : base(concurrencyLevel, collection, comparer) { }
+
+    /// <inheritdoc/>
+    public EventBusConcurrentDictionary(int concurrencyLevel, int capacity, IEqualityComparer<TKey>? comparer)
+        : base(concurrencyLevel, capacity, comparer) { }
+
+    // Code below is inspired by https://gist.github.com/davidfowl/3dac8f7b3d141ae87abf770d5781feed#file-concurrentdictionaryextensions-cs-L53-L87
+
+    /// <summary>
+    /// Asynchronously adds a key/value pair to the <see cref="ConcurrentDictionary{TKey, TValue}"/>
+    /// by using the specified function if the key does not already exist.
+    /// Returns the new value, or the existing value if the key exists.
+    /// </summary>
+    /// <param name="key">The key of the element to add.</param>
+    /// <param name="valueFactory">The function used to generate a value for the key.</param>
+    /// <exception cref="ArgumentNullException">key or valueFactory is null.</exception>
+    /// <exception cref="OverflowException">The dictionary contains too many elements.</exception>
+    /// <returns>
+    /// The value for the key.
+    /// This will be either the existing value for the key if the key is already in the dictionary,
+    /// or the new value if the key was not in the dictionary.
+    /// </returns>
+    public async Task<TValue> GetOrAddAsync(TKey key, Func<TKey, CancellationToken, Task<TValue>> valueFactory, CancellationToken cancellationToken = default)
+    {
+        if (key is null) throw new ArgumentNullException(nameof(key));
+        if (valueFactory is null) throw new ArgumentNullException(nameof(valueFactory));
+
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (TryGetValue(key, out var task)) return await task.ConfigureAwait(false);
+
+            // This is the task that we'll return to all waiters. We'll complete it when the factory is complete
+            var tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
+            if (TryAdd(key, tcs.Task))
+            {
+                try
+                {
+                    var value = await valueFactory(key, cancellationToken).ConfigureAwait(false);
+                    tcs.TrySetResult(value);
+                    return await tcs.Task.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    // Make sure all waiters see the exception
+                    tcs.SetException(ex);
+
+                    // We remove the entry if the factory failed so it's not a permanent failure
+                    // and future gets can retry (this could be a policy)
+                    TryRemove(key, out _);
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
+++ b/src/Tingle.EventBus/Internal/EventBusConcurrentDictionary.cs
@@ -45,8 +45,13 @@ public sealed class EventBusConcurrentDictionary<TKey, TValue> : ConcurrentDicti
     /// </summary>
     /// <param name="key">The key of the element to add.</param>
     /// <param name="valueFactory">The function used to generate a value for the key.</param>
+    /// <param name="cancellationToken">
+    /// Optional <see cref="CancellationToken"/> to propagate notifications that the operation should be cancelled.
+    /// </param>
     /// <exception cref="ArgumentNullException">key or valueFactory is null.</exception>
     /// <exception cref="OverflowException">The dictionary contains too many elements.</exception>
+    /// <exception cref="OperationCanceledException">The token has had cancellation requested.</exception>
+    /// <exception cref="ObjectDisposedException">The associated <see cref="CancellationTokenSource"/> has been disposed.</exception>
     /// <returns>
     /// The value for the key.
     /// This will be either the existing value for the key if the key is already in the dictionary,
@@ -65,7 +70,7 @@ public sealed class EventBusConcurrentDictionary<TKey, TValue> : ConcurrentDicti
 
             // This is the task that we'll return to all waiters. We'll complete it when the factory is complete
             var tcs = new TaskCompletionSource<TValue>(TaskCreationOptions.RunContinuationsAsynchronously);
-            if (TryAdd(key, tcs.Task))
+            if (TryAdd(key, tcs.Task)) // Adding this means the factory is only called once (only when addition works) which is better than GetOrAdd(...)
             {
                 try
                 {


### PR DESCRIPTION
Instead of using a plain dictionary with `SemaphoreSlim` locking use a `ConcurrentDictionary<TKey, Task<TValue>>` inspired by https://gist.github.com/davidfowl/3dac8f7b3d141ae87abf770d5781feed#file-concurrentdictionaryextensions-cs-L53-L87.

This approach results in less code and simpler synchornization.