### PR TITLE
Updates for 2022-11-21 (1)

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Abstractions/Tingle.EventBus.Transports.Amazon.Abstractions.csproj
+++ b/src/Tingle.EventBus.Transports.Amazon.Abstractions/Tingle.EventBus.Transports.Amazon.Abstractions.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.4.4" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.100.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/Tingle.EventBus.Transports.Amazon.Kinesis.csproj
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/Tingle.EventBus.Transports.Amazon.Kinesis.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Kinesis" Version="3.7.0.99" />
+    <PackageReference Include="AWSSDK.Kinesis" Version="3.7.100.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/Tingle.EventBus.Transports.Amazon.Sqs.csproj
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/Tingle.EventBus.Transports.Amazon.Sqs.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.2.70" />
-    <PackageReference Include="AWSSDK.SQS" Version="3.7.1.42" />
+    <PackageReference Include="AWSSDK.SimpleNotificationService" Version="3.7.100.21" />
+    <PackageReference Include="AWSSDK.SQS" Version="3.7.100.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/Tingle.EventBus.Transports.Azure.EventHubs.csproj
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/Tingle.EventBus.Transports.Azure.EventHubs.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/Tingle.EventBus.Transports.Azure.ServiceBus.csproj
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/Tingle.EventBus.Transports.Azure.ServiceBus.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.11.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tingle.EventBus/EventBus.cs
+++ b/src/Tingle.EventBus/EventBus.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Diagnostics;
 using Tingle.EventBus.Ids;
+using Tingle.EventBus.Internal;
 using Tingle.EventBus.Transports;
 
 namespace Tingle.EventBus;

--- a/src/Tingle.EventBus/Internal/DictionaryExtensions.cs
+++ b/src/Tingle.EventBus/Internal/DictionaryExtensions.cs
@@ -1,6 +1,4 @@
-﻿using Tingle.EventBus.Internal;
-
-namespace System.Collections.Generic;
+﻿namespace Tingle.EventBus.Internal;
 
 /// <summary>Extension methods on <see cref="IDictionary{TKey, TValue}"/>.</summary>
 public static class DictionaryExtensions

--- a/src/Tingle.EventBus/Internal/EventBusDictionaryWrapper.cs
+++ b/src/Tingle.EventBus/Internal/EventBusDictionaryWrapper.cs
@@ -1,6 +1,8 @@
 ﻿namespace Tingle.EventBus.Internal;
 
 /// <summary>A wrapper around <see cref="IDictionary{TKey, TValue}"/> for EventBus related functionality.</summary>
+/// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
 /// <remarks>
 /// This type exists instead of extension methods so that it is exposed to other projects/packages in the Tingle.EventBus group
 /// while discouraging external projects/packages/application from using the methods

--- a/src/Tingle.EventBus/Serialization/Xml/XmlEventEnvelope.cs
+++ b/src/Tingle.EventBus/Serialization/Xml/XmlEventEnvelope.cs
@@ -55,7 +55,7 @@ public class XmlEventEnvelope<T> : IEventEnvelope<T> where T : class
     }
 
     ///
-    public XmlHeader[] Headers { get; set; } = new XmlHeader[0];
+    public XmlHeader[] Headers { get; set; } = Array.Empty<XmlHeader>();
 
     /// <inheritdoc/>
     public HostInfo? Host { get; set; }


### PR DESCRIPTION
- Update `Azure.Messaging.*` and `AWSSDK.*` libraries.
- Move `DictionaryExtensions` to the `Internal` namespace/folder.
- Added comments for `TKey` and `TValue` on `EventBusDictionaryWrapper`.
- Initialize `XmlEventEnvelope<T>.Headers` with an empty array.
