### PR TITLE
Duplicate detection settings per event

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
@@ -37,8 +37,8 @@ internal class AmazonKinesisConfigureOptions : AmazonTransportConfigureOptions<A
         var registrations = BusOptions.GetRegistrations(name!);
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast);

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
@@ -34,8 +34,8 @@ internal class AmazonSqsConfigureOptions : AmazonTransportConfigureOptions<Amazo
         var registrations = BusOptions.GetRegistrations(name!);
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast, EntityKind.Queue);

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
@@ -99,8 +99,8 @@ internal class AzureEventHubsConfigureOptions : AzureTransportConfigureOptions<A
         // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast);

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageConfigureOptions.cs
@@ -64,8 +64,8 @@ internal class AzureQueueStorageConfigureOptions : AzureTransportConfigureOption
         // See https://docs.microsoft.com/en-us/rest/api/storageservices/naming-queues-and-metadata#queue-names
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Queue);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
@@ -56,8 +56,8 @@ internal class AzureServiceBusConfigureOptions : AzureTransportConfigureOptions<
         var registrations = BusOptions.GetRegistrations(name!);
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast, EntityKind.Queue);

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
@@ -26,8 +26,8 @@ internal class InMemoryTransportConfigureOptions : EventBusTransportConfigureOpt
         var registrations = BusOptions.GetRegistrations(name);
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast, EntityKind.Queue);

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
@@ -60,8 +60,8 @@ internal class KafkaConfigureOptions : EventBusTransportConfigureOptions<KafkaTr
         // See https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-quotas#common-limits-for-all-tiers
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast);

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
@@ -71,8 +71,8 @@ internal class RabbitMqConfigureOptions : EventBusTransportConfigureOptions<Rabb
         // See https://www.rabbitmq.com/queues.html#:~:text=Names,bytes%20of%20UTF%2D8%20characters.
         foreach (var reg in registrations)
         {
-            // Set the IdFormat
-            options.SetEventIdFormat(reg, BusOptions);
+            // Set the values using defaults
+            options.SetValuesUsingDefaults(reg, BusOptions);
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast, EntityKind.Queue);

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -52,6 +52,18 @@ public class EventRegistration : IEquatable<EventRegistration?>
     public Type? EventSerializerType { get; set; }
 
     /// <summary>
+    /// The duration of duplicate detection history that is maintained by the transport for the event.
+    /// When not null, duplicate messages having the same <see cref="EventContext.Id"/>
+    /// within the given duration will be discarded.
+    /// Defaults to <see langword="null"/>.
+    /// </summary>
+    /// <remarks>
+    /// Duplicate detection can only be done on the transport layer because it requires persistent storage.
+    /// This feature only works if the transport for the event supports duplicate detection.
+    /// </remarks>
+    public TimeSpan? DuplicateDetectionDuration { get; set; }
+
+    /// <summary>
     /// The retry policy to apply specifically for this event.
     /// This is in addition to what may be provided by the SDKs for each transport.
     /// When provided alongside policies on the transport and the bus, it is used as the inner most policy.

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -60,15 +60,6 @@ internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>,
     /// <inheritdoc/>
     public void PostConfigure(string? name, EventBusOptions options)
     {
-        // Check bounds for duplicate detection duration, if duplicate detection is enabled
-        if (options.EnableDeduplication)
-        {
-            var ticks = options.DuplicateDetectionDuration.Ticks;
-            ticks = Math.Max(ticks, TimeSpan.FromSeconds(20).Ticks); // must be more than 20 seconds
-            ticks = Math.Min(ticks, TimeSpan.FromDays(7).Ticks); // must be less than 7 days
-            options.DuplicateDetectionDuration = TimeSpan.FromTicks(ticks);
-        }
-
         // Ensure there is at least one registered transport
         if (options.TransportMap.Count == 0)
         {

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -43,33 +43,26 @@ public class EventBusOptions
     public AsyncRetryPolicy? RetryPolicy { get; set; }
 
     /// <summary>
-    /// Indicates if the messages/events produced require guard against duplicate messages.
-    /// If <see langword="true"/>, duplicate messages having the same <see cref="EventContext.Id"/>
-    /// sent to the same destination within a duration of <see cref="DuplicateDetectionDuration"/> will be discarded.
-    /// Defaults to <see langword="false"/>.
-    /// </summary>
-    /// <remarks>
-    /// Duplicate detection can only be done on the transport layer because it requires persistent storage.
-    /// This feature only works if the transport a message is sent on supports duplicate detection.
-    /// </remarks>
-    public bool EnableDeduplication { get; set; } = false;
-
-    /// <summary>
-    /// The <see cref="TimeSpan"/> duration of duplicate detection history that is maintained by a transport.
-    /// </summary>
-    /// <remarks>
-    /// The default value is 1 minute. Max value is 7 days and minimum is 20 seconds.
-    /// This value is only relevant if <see cref="EnableDeduplication"/> is set to <see langword="true"/>.
-    /// </remarks>
-    public TimeSpan DuplicateDetectionDuration { get; set; } = TimeSpan.FromMinutes(1);
-
-    /// <summary>
     /// Optional default format to use for generated event identifiers when for events where it is not specified.
     /// To specify a value per consumer, use the <see cref="EventRegistration.IdFormat"/> option.
     /// To specify a value per transport, use the <see cref="EventBusTransportOptions.DefaultEventIdFormat"/> option on the specific transport.
     /// Defaults to <see cref="EventIdFormat.Guid"/>.
     /// </summary>
     public EventIdFormat DefaultEventIdFormat { get; set; } = EventIdFormat.Guid;
+
+    /// <summary>
+    /// Gets or sets the default setting for the duration of duplicate detection history that is maintained by a transport.
+    /// When not null, duplicate messages having the same <see cref="EventContext.Id"/> sent to the same destination within
+    /// the given duration will be discarded.
+    /// Defaults to <see langword="null"/>.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.DuplicateDetectionDuration"/> option.
+    /// To specify a value per transport, use the <see cref="EventBusTransportOptions.DefaultDuplicateDetectionDuration"/> option on the specific transport.
+    /// </summary>
+    /// <remarks>
+    /// Duplicate detection can only be done on the transport layer because it requires persistent storage.
+    /// This feature only works if the transport an event is sent on supports duplicate detection.
+    /// </remarks>
+    public TimeSpan? DefaultDuplicateDetectionDuration { get; set; }
 
     /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
@@ -107,7 +107,7 @@ public abstract class EventBusTransportOptions
     /// </summary>
     /// <param name="reg"></param>
     /// <param name="busOptions"></param>
-    public void SetEventIdFormat(EventRegistration reg, EventBusOptions busOptions)
+    public void SetValuesUsingDefaults(EventRegistration reg, EventBusOptions busOptions)
     {
         // prioritize the transport
         reg.IdFormat ??= DefaultEventIdFormat;

--- a/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransportOptions.cs
@@ -72,6 +72,19 @@ public abstract class EventBusTransportOptions
     public EventIdFormat? DefaultEventIdFormat { get; set; }
 
     /// <summary>
+    /// Gets or sets the default setting for the duration of duplicate detection history that is maintained by a transport.
+    /// When not null, duplicate messages having the same <see cref="EventContext.Id"/> sent to the same destination within
+    /// the given duration will be discarded.
+    /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultDuplicateDetectionDuration"/>.
+    /// To specify a value per consumer, use the <see cref="EventRegistration.DuplicateDetectionDuration"/> option.
+    /// </summary>
+    /// <remarks>
+    /// Duplicate detection can only be done on the transport layer because it requires persistent storage.
+    /// This feature only works if the transport supports duplicate detection.
+    /// </remarks>
+    public TimeSpan? DefaultDuplicateDetectionDuration { get; set; }
+
+    /// <summary>
     /// Optional default behaviour for errors encountered in a consumer but are not handled.
     /// This value overrides the default value set on the bus via <see cref="EventBusOptions.DefaultUnhandledConsumerErrorBehaviour"/>.
     /// To specify a value per consumer, use the <see cref="EventConsumerRegistration.UnhandledErrorBehaviour"/> option.
@@ -103,7 +116,8 @@ public abstract class EventBusTransportOptions
     }
 
     /// <summary>
-    /// Set value for <see cref="EventRegistration.IdFormat"/> while prioritizing the transport default over the bus default.
+    /// Set values for <see cref="EventRegistration.IdFormat"/>, and <see cref="EventRegistration.DuplicateDetectionDuration"/>
+    /// while prioritizing the transport default over the bus default.
     /// </summary>
     /// <param name="reg"></param>
     /// <param name="busOptions"></param>
@@ -112,5 +126,9 @@ public abstract class EventBusTransportOptions
         // prioritize the transport
         reg.IdFormat ??= DefaultEventIdFormat;
         reg.IdFormat ??= busOptions.DefaultEventIdFormat;
+
+        // prioritize the transport
+        reg.DuplicateDetectionDuration ??= DefaultDuplicateDetectionDuration;
+        reg.DuplicateDetectionDuration ??= busOptions.DefaultDuplicateDetectionDuration;
     }
 }


### PR DESCRIPTION
Move duplication detection settings to the `EventRegistration` with defaults at the transport and bus level. This way each event can be configured independently even through `appsettings.json` added in #487 