### PR TITLE
Consuming for dead-lettered events

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Kinesis/AmazonKinesisConfigureOptions.cs
@@ -53,7 +53,7 @@ internal class AmazonKinesisConfigureOptions : AmazonTransportConfigureOptions<A
 
             // Consumer names become Queue names and they should not be longer than 128 characters
             // See https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 if (ecr.ConsumerName!.Length > 128)
                 {

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsConfigureOptions.cs
@@ -50,7 +50,7 @@ internal class AmazonSqsConfigureOptions : AmazonTransportConfigureOptions<Amazo
 
             // Consumer names become Queue names and they should not be longer than 80 characters
             // See https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-queues.html
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 if (ecr.ConsumerName!.Length > 80)
                 {

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -397,7 +397,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
                                                                  Message message,
                                                                  CancellationToken cancellationToken)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var messageId = message.MessageId;
         message.TryGetAttribute(MetadataNames.CorrelationId, out var correlationId);

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -435,6 +435,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
                                                      registration: reg,
                                                      identifier: messageId,
                                                      raw: message,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
 
         Logger.ReceivedMessage(messageId: messageId, eventBusId: context.Id, queueUrl: queueUrl);

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -58,7 +58,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
             {
                 var queueUrl = await GetQueueUrlAsync(reg: reg,
                                                       ecr: ecr,
-                                                      deadletter: false,
+                                                      deadletter: ecr.Deadletter,
                                                       cancellationToken: cancellationToken).ConfigureAwait(false);
                 var t = ReceiveAsync(reg: reg,
                                      ecr: ecr,
@@ -445,6 +445,9 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
                                                                     @event: context,
                                                                     scope: scope,
                                                                     cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // dead-letter cannot be dead-lettered again, what else can we do?
+        if (ecr.Deadletter) return; // TODO: figure out what to do when dead-letter fails
 
         if (!successful && ecr.UnhandledErrorBehaviour == UnhandledConsumerErrorBehaviour.Deadletter)
         {

--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -54,7 +54,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var queueUrl = await GetQueueUrlAsync(reg: reg,
                                                       ecr: ecr,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsConfigureOptions.cs
@@ -113,7 +113,7 @@ internal class AzureEventHubsConfigureOptions : AzureTransportConfigureOptions<A
             }
 
             // Consumer names become Consumer Group names and they should not be longer than 256 characters
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 if (ecr.ConsumerName!.Length > 256)
                 {

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -341,7 +341,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
                                                                EventProcessorClient processor,
                                                                ProcessEventArgs args)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         Logger.ProcessorReceivedEvent(eventHubName: processor.EventHubName,
                                       consumerGroup: processor.ConsumerGroup,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -387,6 +387,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
                                                      registration: reg,
                                                      identifier: data.SequenceNumber.ToString(),
                                                      raw: data,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
         Logger.ReceivedEvent(eventBusId: context.Id,
                              eventHubName: processor.EventHubName,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -41,7 +41,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var processor = await GetProcessorAsync(reg: reg, ecr: ecr, cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -49,7 +49,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var t = ReceiveAsync(reg: reg, ecr: ecr, cancellationToken: stoppingCts.Token);
                 receiverTasks.Add(t);

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -299,7 +299,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
                                                                  IServiceScope scope,
                                                                  CancellationToken cancellationToken)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var messageId = message.MessageId;
         using var log_scope = BeginLoggingScopeForConsume(id: messageId,

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -253,7 +253,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
         var mt = GetType().GetMethod(nameof(OnMessageReceivedAsync), flags) ?? throw new InvalidOperationException("Methods should be null");
         var method = mt.MakeGenericMethod(reg.EventType, ecr.ConsumerType);
 
-        var queueClient = await GetQueueClientAsync(reg: reg, deadletter: false, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var queueClient = await GetQueueClientAsync(reg: reg, deadletter: ecr.Deadletter, cancellationToken: cancellationToken).ConfigureAwait(false);
 
         while (!cancellationToken.IsCancellationRequested)
         {
@@ -340,6 +340,9 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
                                                                     @event: context,
                                                                     scope: scope,
                                                                     cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // dead-letter cannot be dead-lettered again, what else can we do?
+        if (ecr.Deadletter) return; // TODO: figure out what to do when dead-letter fails
 
         if (!successful && ecr.UnhandledErrorBehaviour == UnhandledConsumerErrorBehaviour.Deadletter)
         {

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -324,6 +324,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
                                                      registration: reg,
                                                      identifier: (AzureQueueStorageSchedulingId)message,
                                                      raw: message,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
 
         Logger.ReceivedMessage(messageId: messageId, eventBusId: context.Id, queueName: queueClient.Name);

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusConfigureOptions.cs
@@ -73,7 +73,7 @@ internal class AzureServiceBusConfigureOptions : AzureTransportConfigureOptions<
             // When not using Queues, ConsumerName -> SubscriptionName does not happen
             if (reg.EntityKind == EntityKind.Broadcast)
             {
-                foreach (var ecr in reg.Consumers)
+                foreach (var ecr in reg.Consumers.Values)
                 {
                     if (ecr.ConsumerName!.Length > 50)
                     {

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -507,7 +507,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
                                                                  ServiceBusProcessor processor,
                                                                  ProcessMessageEventArgs args)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var entityPath = args.EntityPath;
         var message = args.Message;

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -553,6 +553,11 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
 
         // set the extras
         context.SetServiceBusReceivedMessage(message);
+        if (ecr.Deadletter && context is DeadLetteredEventContext<TEvent> dlec)
+        {
+            dlec.DeadLetterReason = message.DeadLetterReason;
+            dlec.DeadLetterErrorDescription = message.DeadLetterErrorDescription;
+        }
 
         var (successful, ex) = await ConsumeAsync<TEvent, TConsumer>(registration: reg,
                                                                      ecr: ecr,

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -76,7 +76,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var processor = await GetProcessorAsync(reg: reg, ecr: ecr, cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -341,6 +341,9 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
 
                 // Set the number of items to be cached locally
                 PrefetchCount = Options.DefaultPrefetchCount,
+
+                // Set the sub-queue to be used
+                SubQueue = ecr.Deadletter ? SubQueue.DeadLetter : SubQueue.None,
             };
 
             // Allow for the defaults to be overridden

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -543,6 +543,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
                                                      registration: reg,
                                                      identifier: message.SequenceNumber.ToString(),
                                                      raw: message,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
 
         Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventBusId: context.Id, entityPath: entityPath);

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -361,6 +361,7 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
                                                      registration: reg,
                                                      identifier: message.SequenceNumber.ToString(),
                                                      raw: message,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
 
         Logger.ReceivedMessage(sequenceNumber: message.SequenceNumber, eventBusId: context.Id, entityPath: entityPath);

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -70,7 +70,7 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
         var registrations = GetRegistrations();
         foreach (var reg in registrations)
         {
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var processor = await GetProcessorAsync(reg: reg, ecr: ecr, cancellationToken: cancellationToken).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -326,7 +326,7 @@ public class InMemoryTransport : EventBusTransport<InMemoryTransportOptions>
                                                                  InMemoryProcessor processor,
                                                                  ProcessMessageEventArgs args)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var entityPath = processor.EntityPath;
         var message = args.Message;

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransportConfigureOptions.cs
@@ -31,6 +31,17 @@ internal class InMemoryTransportConfigureOptions : EventBusTransportConfigureOpt
 
             // Ensure the entity type is allowed
             options.EnsureAllowedEntityKind(reg, EntityKind.Broadcast, EntityKind.Queue);
+
+            // This does not support dead-letter yet
+            foreach (var ecr in reg.Consumers.Values)
+            {
+                if (ecr.Deadletter)
+                {
+                    throw new InvalidOperationException($"ConsumerName '{ecr.ConsumerName}' is setup for dead-letter but the InMemory "
+                                                       + "implementation doesn't yet support it.");
+                }
+            }
+
         }
     }
 }

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
@@ -75,7 +75,7 @@ internal class KafkaConfigureOptions : EventBusTransportConfigureOptions<KafkaTr
             }
 
             // Consumer names become Consumer Group IDs and they should not be longer than 255 characters
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 if (ecr.ConsumerName!.Length > 255)
                 {

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaConfigureOptions.cs
@@ -74,13 +74,20 @@ internal class KafkaConfigureOptions : EventBusTransportConfigureOptions<KafkaTr
                                                    + "Kafka does not allow more than 255 characters for Topic names.");
             }
 
-            // Consumer names become Consumer Group IDs and they should not be longer than 255 characters
             foreach (var ecr in reg.Consumers.Values)
             {
+                // Consumer names become Consumer Group IDs and they should not be longer than 255 characters
                 if (ecr.ConsumerName!.Length > 255)
                 {
                     throw new InvalidOperationException($"ConsumerName '{ecr.ConsumerName}' generated from '{ecr.ConsumerType.Name}' is too long. "
                                                        + "Kafka does not allow more than 255 characters for Consumer Group IDs.");
+                }
+
+                // This does not support dead-letter yet
+                if (ecr.Deadletter)
+                {
+                    throw new InvalidOperationException($"ConsumerName '{ecr.ConsumerName}' is setup for dead-letter but the Kafka "
+                                                       + "implementation doesn't yet support it.");
                 }
             }
         }

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -269,7 +269,7 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
                                                                ConsumeResult<string, byte[]> result,
                                                                CancellationToken cancellationToken)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var message = result.Message;
         var messageKey = message.Key;

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -234,7 +234,7 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
                 var reg = GetRegistrations().Single(r => r.EventName == topic);
 
                 // form the generic method
-                var ecr = reg.Consumers.Single(); // only one consumer per event
+                var ecr = reg.Consumers.Values.Single(); // only one consumer per event
                 var method = mt.MakeGenericMethod(reg.EventType, ecr.ConsumerType);
                 await ((Task)method.Invoke(this, new object[] { reg, ecr, result, cancellationToken, })!).ConfigureAwait(false);
 

--- a/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
+++ b/src/Tingle.EventBus.Transports.Kafka/KafkaTransport.cs
@@ -294,6 +294,7 @@ public class KafkaTransport : EventBusTransport<KafkaTransportOptions>, IDisposa
                                                      registration: reg,
                                                      identifier: result.Offset.ToString(),
                                                      raw: message,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
         Logger.ReceivedEvent(messageKey, context.Id);
         var (successful, _) = await ConsumeAsync<TEvent, TConsumer>(registration: reg,

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
@@ -84,13 +84,20 @@ internal class RabbitMqConfigureOptions : EventBusTransportConfigureOptions<Rabb
                                                    + "RabbitMQ does not allow more than 255 characters for Exchange names.");
             }
 
-            // Consumer names become Queue names and they should not be longer than 255 characters
             foreach (var ecr in reg.Consumers.Values)
             {
+                // Consumer names become Queue names and they should not be longer than 255 characters
                 if (ecr.ConsumerName!.Length > 255)
                 {
                     throw new InvalidOperationException($"ConsumerName '{ecr.ConsumerName}' generated from '{ecr.ConsumerType.Name}' is too long. "
                                                        + "RabbitMQ does not allow more than 255 characters for Queue names.");
+                }
+
+                // This does not support dead-letter yet
+                if (ecr.Deadletter)
+                {
+                    throw new InvalidOperationException($"ConsumerName '{ecr.ConsumerName}' is setup for dead-letter but the RabbitMQ "
+                                                       + "implementation doesn't yet support it.");
                 }
             }
         }

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
@@ -85,7 +85,7 @@ internal class RabbitMqConfigureOptions : EventBusTransportConfigureOptions<Rabb
             }
 
             // Consumer names become Queue names and they should not be longer than 255 characters
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 if (ecr.ConsumerName!.Length > 255)
                 {

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -318,6 +318,7 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
                                                      registration: reg,
                                                      identifier: messageId,
                                                      raw: args,
+                                                     deadletter: ecr.Deadletter,
                                                      cancellationToken: cancellationToken).ConfigureAwait(false);
         Logger.LogInformation("Received message: '{MessageId}' containing Event '{Id}'",
                               messageId,

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -263,7 +263,7 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
         foreach (var reg in registrations)
         {
             var exchangeName = reg.EventName!;
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 var queueName = ecr.ConsumerName!;
 

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -287,7 +287,7 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
                                                                  BasicDeliverEventArgs args,
                                                                  CancellationToken cancellationToken)
         where TEvent : class
-        where TConsumer : IEventConsumer<TEvent>
+        where TConsumer : IEventConsumer
     {
         var messageId = args.BasicProperties?.MessageId;
         using var log_scope = BeginLoggingScopeForConsume(id: messageId,

--- a/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
+++ b/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
@@ -28,7 +28,7 @@ internal class DefaultEventConfigurator : IEventConfigurator
         // bind from IConfiguration
         var configuration = configurationProvider.Configuration.GetSection($"Events:{registration.EventType.FullName}");
         configuration.Bind(registration);
-        foreach (var ecr in registration.Consumers)
+        foreach (var ecr in registration.Consumers.Values)
         {
             configuration.GetSection($"Consumers:{ecr.ConsumerType.FullName}").Bind(ecr);
         }
@@ -117,7 +117,7 @@ internal class DefaultEventConfigurator : IEventConfigurator
         // prefix is either the one provided or the application name
         var prefix = options.ConsumerNamePrefix ?? environment.ApplicationName;
 
-        foreach (var ecr in reg.Consumers)
+        foreach (var ecr in reg.Consumers.Values)
         {
             // set the consumer name, if not set
             if (string.IsNullOrWhiteSpace(ecr.ConsumerName))

--- a/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
@@ -25,6 +25,14 @@ public class EventConsumerRegistration : IEquatable<EventConsumerRegistration>
     public string? ConsumerName { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating if the consumer should be connected to the dead-letter sub-queue.
+    /// For transports that do not support dead-letter sub-queues, a separate queue is created.
+    /// When set to <see langword="true"/>, you must use <see cref="IDeadLetteredEventConsumer{T}"/>
+    /// to consume events.
+    /// </summary>
+    public bool Deadletter { get; internal set; }
+
+    /// <summary>
     /// The behaviour for unhandled errors when consuming events via the
     /// <see cref="IEventConsumer{T}.ConsumeAsync(EventContext{T}, CancellationToken)"/>
     /// method.

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -82,7 +82,7 @@ public class EventRegistration : IEquatable<EventRegistration?>
     /// <remarks>
     /// This is backed by a <see cref="HashSet{T}"/> to ensure no duplicates.
     /// </remarks>
-    public ICollection<EventConsumerRegistration> Consumers { get; set; } = new HashSet<EventConsumerRegistration>();
+    public Dictionary<Type, EventConsumerRegistration> Consumers { get; } = new();
 
     /// <summary>
     /// Gets a key/value collection that can be used to organize and share data across components

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -99,10 +99,10 @@ public class EventBusBuilder
         // Calling ConfigureOptions results in more than one call to the configuration implementations so we have to implement our own logic
         // TODO: remove after https://github.com/dotnet/runtime/issues/42358 is addressed
 
-        static Type[] GetInterfacesOnType(Type t) => t.GetInterfaces();
         static IEnumerable<Type> FindConfigurationServices(Type type)
         {
-            foreach (var t in GetInterfacesOnType(type))
+            var interfaces = type.GetInterfaces();
+            foreach (var t in interfaces)
             {
                 if (t.IsGenericType)
                 {
@@ -151,23 +151,18 @@ public class EventBusBuilder
             throw new InvalidOperationException($"Abstract consumer types are not allowed.");
         }
 
-        var genericConsumerType = typeof(IEventConsumer<>);
-        var eventTypes = new List<Type>();
+        var eventTypes = new List<(Type type, bool deadletter)>();
 
-        // get events from each implementation of IEventConsumer<TEvent>
+        // get events from each implementation of IEventConsumer<TEvent> or IDeadLetteredEventConsumer<TEvent>
         var interfaces = consumerType.GetInterfaces();
-        foreach (var ifType in interfaces)
+        foreach (var type in interfaces)
         {
-            if (ifType.IsGenericType && ifType.GetGenericTypeDefinition() == genericConsumerType)
-            {
-                var et = ifType.GenericTypeArguments[0];
-                if (et.IsAbstract)
-                {
-                    throw new InvalidOperationException($"Invalid event type '{et.FullName}'. Abstract types are not allowed.");
-                }
+            if (!type.IsGenericType) continue;
 
-                eventTypes.Add(et);
-            }
+            var gtd = type.GetGenericTypeDefinition();
+            if (gtd != typeof(IEventConsumer<>) && gtd != typeof(IDeadLetteredEventConsumer<>)) continue;
+
+            eventTypes.Add((type.GenericTypeArguments[0], gtd == typeof(IDeadLetteredEventConsumer<>)));
         }
 
         // we must have at least one implemented event
@@ -176,10 +171,18 @@ public class EventBusBuilder
             throw new InvalidOperationException($"{consumerType.FullName} must implement '{nameof(IEventConsumer)}<TEvent>' at least once.");
         }
 
+        foreach (var (et, _) in eventTypes)
+        {
+            if (et.IsAbstract)
+            {
+                throw new InvalidOperationException($"Invalid event type '{et.FullName}'. Abstract types are not allowed.");
+            }
+        }
+
         // add the event types to the registrations
         return Configure(options =>
         {
-            foreach (var et in eventTypes)
+            foreach (var (et, deadletter) in eventTypes)
             {
                 // get or create a simple EventRegistration
                 var reg = options.Registrations.GetOrAdd(et, t => new EventRegistration(t));
@@ -187,7 +190,7 @@ public class EventBusBuilder
                 // get or create a simple ConsumerRegistration
                 if (!reg.Consumers.TryGetValue(consumerType, out var ecr))
                 {
-                    ecr = new EventConsumerRegistration(consumerType);
+                    ecr = new EventConsumerRegistration(consumerType) { Deadletter = deadletter, };
                     reg.Consumers.Add(consumerType, ecr);
                 }
 

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -184,14 +184,15 @@ public class EventBusBuilder
                 // get or create a simple EventRegistration
                 var reg = options.Registrations.GetOrAdd(et, t => new EventRegistration(t));
 
-                // create a ConsumerRegistration
-                var ecr = new EventConsumerRegistration(consumerType: consumerType);
+                // get or create a simple ConsumerRegistration
+                if (!reg.Consumers.TryGetValue(consumerType, out var ecr))
+                {
+                    ecr = new EventConsumerRegistration(consumerType);
+                    reg.Consumers.Add(consumerType, ecr);
+                }
 
                 // call the configuration function
                 configure?.Invoke(reg, ecr);
-
-                // add the consumer to the registration
-                reg.Consumers.Add(ecr);
             }
         });
     }
@@ -220,11 +221,7 @@ public class EventBusBuilder
             var ct = typeof(TConsumer);
             foreach (var registration in options.Registrations.Values)
             {
-                var target = registration.Consumers.SingleOrDefault(c => c.ConsumerType == ct);
-                if (target is not null)
-                {
-                    registration.Consumers.Remove(target);
-                }
+                registration.Consumers.Remove(ct);
             }
         });
     }

--- a/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusConfigureOptions.cs
@@ -113,7 +113,7 @@ internal class EventBusConfigureOptions : IConfigureOptions<EventBusOptions>,
         // Ensure there are no consumers with the same name per event
         foreach (var evr in registrations)
         {
-            var conflict = evr.Consumers.GroupBy(ecr => ecr.ConsumerName).FirstOrDefault(kvp => kvp.Count() > 1);
+            var conflict = evr.Consumers.Values.GroupBy(ecr => ecr.ConsumerName).FirstOrDefault(kvp => kvp.Count() > 1);
             if (conflict != null)
             {
                 var names = conflict.Select(r => r.ConsumerType.FullName);

--- a/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusOptions.cs
@@ -153,12 +153,7 @@ public class EventBusOptions
                                                                 [NotNullWhen(true)] out EventConsumerRegistration? ecr)
     {
         ecr = default;
-        if (Registrations.TryGetValue(typeof(TEvent), out reg))
-        {
-            ecr = reg.Consumers.SingleOrDefault(cr => cr.ConsumerType == typeof(TConsumer));
-            if (ecr is not null) return true;
-        }
-        return false;
+        return Registrations.TryGetValue(typeof(TEvent), out reg) && reg.Consumers.TryGetValue(typeof(TConsumer), out ecr);
     }
 
     /// <summary>

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -4,9 +4,7 @@ using Tingle.EventBus.Serialization;
 
 namespace Tingle.EventBus;
 
-/// <summary>
-/// Generic context for an event.
-/// </summary>
+/// <summary>Generic context for an event.</summary>
 public abstract class EventContext : WrappedEventPublisher
 {
     private readonly HostInfo? hostInfo;
@@ -180,9 +178,7 @@ public abstract class EventContext : WrappedEventPublisher
     #endregion
 }
 
-/// <summary>
-/// The context for a specific event.
-/// </summary>
+/// <summary>The context for a specific event.</summary>
 /// <typeparam name="T">The type of event carried.</typeparam>
 public class EventContext<T> : EventContext where T : class
 {
@@ -208,9 +204,7 @@ public class EventContext<T> : EventContext where T : class
     public T Event { get; set; }
 }
 
-/// <summary>
-/// The context for a specific dead-lettered event.
-/// </summary>
+/// <summary>The context for a specific dead-lettered event.</summary>
 /// <typeparam name="T">The type of event carried.</typeparam>
 public class DeadLetteredEventContext<T> : EventContext where T : class
 {

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -218,4 +218,14 @@ public class DeadLetteredEventContext<T> : EventContext where T : class
     /// The dead-lettered event.
     /// </summary>
     public T Event { get; set; }
+
+    /// <summary>
+    /// Gets the dead letter reason for the event.
+    /// </summary>
+    public string? DeadLetterReason { get; set; }
+
+    /// <summary>
+    /// Gets the dead letter error description for the event.
+    /// </summary>
+    public string? DeadLetterErrorDescription { get; set; }
 }

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -141,10 +141,7 @@ public abstract class EventContext : WrappedEventPublisher
     /// <exception cref="InvalidCastException">This conversion is not supported.</exception>
     /// <exception cref="FormatException">The value is not in a format recognized by <typeparamref name="T"/>.</exception>
     /// <exception cref="OverflowException">The value represents a number that is out of the range of <typeparamref name="T"/>.</exception>
-    public T? GetHeaderValue<T>(string key) where T : IConvertible
-    {
-        return TryGetHeaderValue<T>(key, out var value) ? value : default;
-    }
+    public T? GetHeaderValue<T>(string key) where T : IConvertible => TryGetHeaderValue<T>(key, out var value) ? value : default;
 
     /// <summary>
     /// Gets the header value associated with the specified header key
@@ -161,14 +158,9 @@ public abstract class EventContext : WrappedEventPublisher
     /// <exception cref="FormatException">The value is not in a format recognized by <typeparamref name="T"/>.</exception>
     /// <exception cref="OverflowException">The value represents a number that is out of the range of <typeparamref name="T"/>.</exception>
     /// <exception cref="KeyNotFoundException">The <paramref name="key"/> was not found in the headers.</exception>
-    public T? GetRequiredHeaderValue<T>(string key) where T : IConvertible
-    {
-        if (TryGetHeaderValue<T>(key, out var value)) return value;
-        throw new KeyNotFoundException(key);
-    }
+    public T? GetRequiredHeaderValue<T>(string key) where T : IConvertible => GetHeaderValue<T>(key) ?? throw new KeyNotFoundException(key);
 
     #endregion
-
 }
 
 /// <summary>

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -179,26 +179,11 @@ public class EventContext<T> : EventContext where T : class
         Event = @event;
     }
 
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="publisher">The <see cref="IEventPublisher"/> to use.</param>
-    /// <param name="event">Value for <see cref="Event"/>.</param>
-    /// <param name="hostInfo">The <see cref="HostInfo"/> of the event sender.</param>
-    protected EventContext(IEventPublisher publisher, T @event, HostInfo? hostInfo) : base(publisher, hostInfo)
+    // marked internal because of the forced null forgiving operator
+    internal EventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, ContentType? contentType, string? transportIdentifier)
+        : base(publisher, envelope.Host)
     {
-        Event = @event;
-    }
-
-    /// <summary>
-    /// 
-    /// </summary>
-    /// <param name="publisher">The <see cref="IEventPublisher"/> to use.</param>
-    /// <param name="event">Value for <see cref="Event"/>.</param>
-    /// <param name="envelope">Envelope containing details for the event.</param>
-    /// <param name="contentType">Value for <see cref="EventContext.ContentType"/></param>
-    public EventContext(IEventPublisher publisher, T @event, IEventEnvelope envelope, ContentType? contentType) : this(publisher, @event, envelope.Host)
-    {
+        Event = envelope.Event!;
         Id = envelope.Id;
         RequestId = envelope.RequestId;
         CorrelationId = envelope.CorrelationId;
@@ -207,12 +192,6 @@ public class EventContext<T> : EventContext where T : class
         Sent = envelope.Sent;
         Headers = envelope.Headers;
         ContentType = contentType;
-    }
-
-    // marked internal because of the forced null forgiving operator
-    internal EventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, ContentType? contentType, string? transportIdentifier)
-        : this(publisher, envelope.Event!, envelope, contentType)
-    {
         TransportIdentifier = transportIdentifier;
     }
 

--- a/src/Tingle.EventBus/EventContext.cs
+++ b/src/Tingle.EventBus/EventContext.cs
@@ -192,8 +192,8 @@ public class EventContext<T> : EventContext where T : class
         Event = @event;
     }
 
-    internal EventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, ContentType? contentType, string? transportIdentifier)
-        : base(publisher, envelope, contentType, transportIdentifier)
+    internal EventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, DeserializationContext deserializationContext)
+        : base(publisher, envelope, deserializationContext.ContentType, deserializationContext.Identifier)
     {
         Event = envelope.Event!;
     }
@@ -208,8 +208,8 @@ public class EventContext<T> : EventContext where T : class
 /// <typeparam name="T">The type of event carried.</typeparam>
 public class DeadLetteredEventContext<T> : EventContext where T : class
 {
-    internal DeadLetteredEventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, ContentType? contentType, string? transportIdentifier)
-        : base(publisher, envelope, contentType, transportIdentifier)
+    internal DeadLetteredEventContext(IEventPublisher publisher, IEventEnvelope<T> envelope, DeserializationContext deserializationContext)
+        : base(publisher, envelope, deserializationContext.ContentType, deserializationContext.Identifier)
     {
         Event = envelope.Event!;
     }

--- a/src/Tingle.EventBus/IEventConsumer.cs
+++ b/src/Tingle.EventBus/IEventConsumer.cs
@@ -21,3 +21,17 @@ public interface IEventConsumer<T> : IEventConsumer where T : class
     /// <returns></returns>
     Task ConsumeAsync(EventContext<T> context, CancellationToken cancellationToken);
 }
+
+/// <summary>
+/// Contract describing a consumer of a dead-lettered event.
+/// </summary>
+public interface IDeadLetteredEventConsumer<T> : IEventConsumer where T : class
+{
+    /// <summary>
+    /// Consume a dead-lettered event of the provided type.
+    /// </summary>
+    /// <param name="context">The context of the event</param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    Task ConsumeAsync(DeadLetteredEventContext<T> context, CancellationToken cancellationToken);
+}

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -76,7 +76,9 @@ public abstract class AbstractEventSerializer : IEventSerializer
 
         // Create the context
         var publisher = context.ServiceProvider.GetRequiredService<IEventPublisher>();
-        return new EventContext<T>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: context.Identifier);
+        return context.Deadletter
+            ? new DeadLetteredEventContext<T>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: context.Identifier)
+            : new EventContext<T>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: context.Identifier);
     }
 
     /// <inheritdoc/>

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -45,7 +45,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
     protected ILogger Logger { get; }
 
     /// <inheritdoc/>
-    public async Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default)
+    public async Task<EventContext?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default)
         where T : class
     {
         // Assume first media type if none is specified

--- a/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/AbstractEventSerializer.cs
@@ -45,7 +45,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
     protected ILogger Logger { get; }
 
     /// <inheritdoc/>
-    public async Task<EventContext?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default)
+    public async Task<IEventEnvelope<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default)
         where T : class
     {
         // Assume first media type if none is specified
@@ -74,11 +74,7 @@ public abstract class AbstractEventSerializer : IEventSerializer
             return null;
         }
 
-        // Create the context
-        var publisher = context.ServiceProvider.GetRequiredService<IEventPublisher>();
-        return context.Deadletter
-            ? new DeadLetteredEventContext<T>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: context.Identifier)
-            : new EventContext<T>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: context.Identifier);
+        return envelope;
     }
 
     /// <inheritdoc/>

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -55,4 +55,9 @@ public sealed class DeserializationContext
     /// whereas for Service Bus this is of type Azure.Messaging.ServiceBus.ServiceBusMessage.
     /// </summary>
     public object? RawTransportData { get; init; }
+
+    /// <summary>
+    /// Indicates if the deserialization is being done on a deadletter entity.
+    /// </summary>
+    public bool Deadletter { get; init; }
 }

--- a/src/Tingle.EventBus/Serialization/DeserializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/DeserializationContext.cs
@@ -9,22 +9,15 @@ namespace Tingle.EventBus.Serialization;
 public sealed class DeserializationContext
 {
     /// <summary>Creates and instance of <see cref="DeserializationContext"/>.</summary>
-    /// <param name="serviceProvider">The provider to use to resolve any required services in the given scope.</param>
     /// <param name="body">The <see cref="BinaryData"/> containing the raw data.</param>
     /// <param name="registration">Registration for this event being deserialized.</param>
     /// <param name="identifier">Identifier given by the transport for the event to be deserialized.</param>
-    public DeserializationContext(IServiceProvider serviceProvider, BinaryData body, EventRegistration registration, string? identifier = null)
+    public DeserializationContext(BinaryData body, EventRegistration registration, string? identifier = null)
     {
-        ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         Body = body ?? throw new ArgumentNullException(nameof(body));
         Registration = registration ?? throw new ArgumentNullException(nameof(registration));
         Identifier = identifier;
     }
-
-    /// <summary>
-    /// The provider to use to resolve any required services in the given scope.
-    /// </summary>
-    public IServiceProvider ServiceProvider { get; }
 
     /// <summary>
     /// The <see cref="BinaryData"/> containing the raw data.
@@ -55,9 +48,4 @@ public sealed class DeserializationContext
     /// whereas for Service Bus this is of type Azure.Messaging.ServiceBus.ServiceBusMessage.
     /// </summary>
     public object? RawTransportData { get; init; }
-
-    /// <summary>
-    /// Indicates if the deserialization is being done on a deadletter entity.
-    /// </summary>
-    public bool Deadletter { get; init; }
 }

--- a/src/Tingle.EventBus/Serialization/IEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/IEventSerializer.cs
@@ -21,5 +21,5 @@ public interface IEventSerializer
     /// <param name="context">The <see cref="DeserializationContext"/> to use.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<EventContext?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class;
+    Task<IEventEnvelope<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/Tingle.EventBus/Serialization/IEventSerializer.cs
+++ b/src/Tingle.EventBus/Serialization/IEventSerializer.cs
@@ -21,5 +21,5 @@ public interface IEventSerializer
     /// <param name="context">The <see cref="DeserializationContext"/> to use.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
-    Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class;
+    Task<EventContext?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class;
 }

--- a/src/Tingle.EventBus/Serialization/SerializationContext.cs
+++ b/src/Tingle.EventBus/Serialization/SerializationContext.cs
@@ -8,20 +8,13 @@ namespace Tingle.EventBus.Serialization;
 public sealed class SerializationContext<T> where T : class
 {
     /// <summary>Creates and instance of <see cref="SerializationContext{T}"/>.</summary>
-    /// <param name="serviceProvider">The provider to use to resolve any required services in the given scope.</param>
     /// <param name="event">The event to be serialized.</param>
     /// <param name="registration">Registration for this event being deserialized.</param>
-    public SerializationContext(IServiceProvider serviceProvider, EventContext<T> @event, EventRegistration registration)
+    public SerializationContext(EventContext<T> @event, EventRegistration registration)
     {
-        ServiceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         Registration = registration ?? throw new ArgumentNullException(nameof(registration));
         Event = @event ?? throw new ArgumentNullException(nameof(@event));
     }
-
-    /// <summary>
-    /// The provider to use to resolve any required services in the given scope.
-    /// </summary>
-    public IServiceProvider ServiceProvider { get; }
 
     /// <summary>
     /// The event to be serialized.

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -277,6 +277,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
     /// <param name="registration">The bus registration for this event.</param>
     /// <param name="identifier">Identifier given by the transport for the event to be deserialized.</param>
     /// <param name="raw">The raw data provided by the transport without any manipulation.</param>
+    /// <param name="deadletter">Whether the event is from a dead-letter entity.</param>
     /// <param name="cancellationToken"></param>
     /// <returns></returns>
     protected async Task<EventContext> DeserializeAsync<TEvent>(IServiceScope scope,
@@ -285,6 +286,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
                                                                 EventRegistration registration,
                                                                 string? identifier,
                                                                 object? raw,
+                                                                bool deadletter,
                                                                 CancellationToken cancellationToken = default)
         where TEvent : class
     {
@@ -292,6 +294,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         {
             ContentType = contentType,
             RawTransportData = raw,
+            Deadletter = deadletter,
         };
         return await DeserializeAsync<TEvent>(ctx, cancellationToken).ConfigureAwait(false);
     }

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -86,7 +86,7 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
             // Combine the retry policies
             PollyHelper.CombineIfNeeded(BusOptions, Options, reg);
 
-            foreach (var ecr in reg.Consumers)
+            foreach (var ecr in reg.Consumers.Values)
             {
                 // Set unhandled error behaviour
                 ecr.UnhandledErrorBehaviour ??= Options.DefaultUnhandledConsumerErrorBehaviour;

--- a/src/Tingle.EventBus/Transports/EventBusTransport.cs
+++ b/src/Tingle.EventBus/Transports/EventBusTransport.cs
@@ -284,8 +284,8 @@ public abstract class EventBusTransport<TOptions> : IEventBusTransport where TOp
         // Create the context
         var publisher = provider.GetRequiredService<IEventPublisher>();
         return deadletter
-            ? new DeadLetteredEventContext<TEvent>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: ctx.Identifier)
-            : new EventContext<TEvent>(publisher: publisher, envelope: envelope, contentType: contentType, transportIdentifier: ctx.Identifier);
+            ? new DeadLetteredEventContext<TEvent>(publisher: publisher, envelope: envelope, deserializationContext: ctx)
+            : new EventContext<TEvent>(publisher: publisher, envelope: envelope, deserializationContext: ctx);
     }
 
     /// <summary>

--- a/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
+++ b/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
@@ -161,9 +161,9 @@ public class DefaultEventConfiguratorTests
         options.Naming.SuffixConsumerName = suffixEventName;
 
         var registration = new EventRegistration(eventType);
-        registration.Consumers.Add(new EventConsumerRegistration(consumerType));
+        registration.Consumers.Add(consumerType, new EventConsumerRegistration(consumerType));
 
-        var creg = Assert.Single(registration.Consumers);
+        var creg = Assert.Single(registration.Consumers.Values);
         configurator.ConfigureEventName(registration, options.Naming);
         configurator.ConfigureConsumerNames(registration, options.Naming);
         Assert.Equal(expected, creg.ConsumerName);

--- a/tests/Tingle.EventBus.Tests/Configurator/FakeEventSerializer1.cs
+++ b/tests/Tingle.EventBus.Tests/Configurator/FakeEventSerializer1.cs
@@ -5,7 +5,7 @@ namespace Tingle.EventBus.Tests.Configurator;
 internal class FakeEventSerializer1 : IEventSerializer
 {
     /// <inheritdoc/>
-    public Task<EventContext<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class
+    public Task<IEventEnvelope<T>?> DeserializeAsync<T>(DeserializationContext context, CancellationToken cancellationToken = default) where T : class
     {
         throw new NotImplementedException();
     }

--- a/tests/Tingle.EventBus.Tests/EventBusBuilderTests.cs
+++ b/tests/Tingle.EventBus.Tests/EventBusBuilderTests.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Options;
+using Tingle.EventBus.Configuration;
+using Tingle.EventBus.Tests.Configurator;
+using Tingle.EventBus.Transports;
+
+namespace Tingle.EventBus.Tests;
+
+public class EventBusBuilderTests
+{
+    [Fact]
+    public void DeadletterConsumerIsRegistered()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IHostEnvironment>(new FakeHostEnvironment("app1"));
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        services.AddEventBus(builder =>
+        {
+            builder.AddConsumer<DummyConsumer>();
+            builder.Configure(o => o.AddTransport<DummyTransport>("Dummy", null));
+        });
+
+        var provider = services.BuildServiceProvider();
+        var options = provider.GetRequiredService<IOptions<EventBusOptions>>().Value;
+        Assert.Equal(2, options.Registrations.Count);
+
+        var reg = Assert.Contains(typeof(TestEvent1), (IDictionary<Type, EventRegistration>)options.Registrations);
+        var ecr = Assert.Single(reg.Consumers).Value;
+        Assert.Equal(typeof(DummyConsumer), ecr.ConsumerType);
+        Assert.False(ecr.Deadletter);
+
+        reg = Assert.Contains(typeof(TestEvent2), (IDictionary<Type, EventRegistration>)options.Registrations);
+        ecr = Assert.Single(reg.Consumers).Value;
+        Assert.Equal(typeof(DummyConsumer), ecr.ConsumerType);
+        Assert.True(ecr.Deadletter);
+    }
+
+    internal class DummyConsumer : IEventConsumer<TestEvent1>, IDeadLetteredEventConsumer<TestEvent2>
+    {
+        public Task ConsumeAsync(EventContext<TestEvent1> context, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+        public Task ConsumeAsync(DeadLetteredEventContext<TestEvent2> context, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    internal class DummyTransport : IEventBusTransport
+    {
+        public string Name => throw new NotImplementedException();
+
+        public Task CancelAsync<TEvent>(string id, EventRegistration registration, CancellationToken cancellationToken = default) where TEvent : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task CancelAsync<TEvent>(IList<string> ids, EventRegistration registration, CancellationToken cancellationToken = default) where TEvent : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public EventBusTransportOptions? GetOptions()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Initialize(EventBusTransportRegistration registration)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<ScheduledResult?> PublishAsync<TEvent>(EventContext<TEvent> @event, EventRegistration registration, DateTimeOffset? scheduled = null, CancellationToken cancellationToken = default) where TEvent : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<IList<ScheduledResult>?> PublishAsync<TEvent>(IList<EventContext<TEvent>> events, EventRegistration registration, DateTimeOffset? scheduled = null, CancellationToken cancellationToken = default) where TEvent : class
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Support consuming events from dead-letter entities. This works best for Azure Service Bus that has the concept of a dead-letter sub-queue. For other transports, this is supported using a separate dead-letter entity that is usually named `{entity-name}-deadletter`. These are mainly meant for simple scenarios where the handler cannot error because we cannot dead-letter a dead-lettered event.

The only difference between consuming normal and dead-lettered events is using `IDeadLetteredEventConsumer<TEvent>` instead of `IEventConsumer<TEvent>`. The rest of the details are handled automatically. For example:
```cs
public class DummyConsumer : IDeadLetteredEventConsumer<TestEvent2>
{
    public Task ConsumeAsync(DeadLetteredEventContext<TestEvent2> context, CancellationToken cancellationToken = default)
    {
        // ...
        throw new NotImplementedException();
    }
}
```

Registration is still the same:
```cs
services.AddEventBus(builder => builder.AddConsumer<DummyConsumer>());
```