### PR TITLE
Appending EventName to ConsumerName should not happen when using ConsumerNameAttribute

### DIFF
--- a/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
+++ b/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
@@ -137,11 +137,11 @@ internal class DefaultEventConfigurator : IEventConfigurator
                         _ => throw new InvalidOperationException($"'{nameof(options.ConsumerNameSource)}.{options.ConsumerNameSource}' is not supported"),
                     };
                     name = options.ApplyNamingConvention(name);
+                    name = options.SuffixConsumerName ? options.Join(name, reg.EventName) : name; // Append the EventName to ensure it is unique
                     name = options.AppendScope(name);
                     name = options.ReplaceInvalidCharacters(name);
                 }
-                // Appending the EventName to the consumer name can ensure it is unique
-                ecr.ConsumerName = options.SuffixConsumerName ? options.Join(name, reg.EventName) : name;
+                ecr.ConsumerName = name;
             }
         }
     }

--- a/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
+++ b/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
@@ -121,16 +121,16 @@ public class DefaultEventConfiguratorTests
         "service1.tingle.event.bus.tests.configurator.test.consumer1.tingle.event.bus.tests.configurator.test.event1")]
 
     // Overriden by attribute
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer.sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "sample-consumer.sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer-sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer_sample-event")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer.sample-event")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
 
     // Appending
     [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", false, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1")]
@@ -140,6 +140,8 @@ public class DefaultEventConfiguratorTests
     [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, false, ConsumerNameSource.TypeName, NamingConvention.DotCase, "tingle.event.bus.tests.configurator.test.consumer1")]
     [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer")]
     [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase,
+        "tingle-event-bus-tests-configurator-test-consumer1-tingle-event-bus-tests-configurator-test-event1")]
     public void SetConsumerName_Works(Type eventType,
                                       Type consumerType,
                                       bool useFullTypeNames,


### PR DESCRIPTION
When `ConsumerNameAttribute` is used on a class implementing `IEventConsumer`, the value supplied should be used as is and not appended to. When the consumer implements more than one `IEventConsumer<T>`, the value can be overridden via `ConfigureConsumer<TEvent, TConsumer>(...)`, `AddConsumer<TConsumer>(...)` or via `IConfiguration` for each event consumed in the consumer.