### PR TITLE
Allow other consumer groups besides $Default for Azure IoT Hub implementation

### DIFF
--- a/samples/AzureIotHub/AzureIotEventsConsumer.cs
+++ b/samples/AzureIotHub/AzureIotEventsConsumer.cs
@@ -1,8 +1,10 @@
 ﻿using System.Text.Json;
+using Tingle.EventBus.Configuration;
 using Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
 namespace AzureIotHub;
 
+[ConsumerName("$Default")] // or [ConsumerName(EventHubConsumerClient.DefaultConsumerGroupName)]
 internal class AzureIotEventsConsumer : IEventConsumer<MyIotHubEvent>
 {
     private static readonly JsonSerializerOptions serializerOptions = new(JsonSerializerDefaults.Web) { WriteIndented = true, };

--- a/samples/MultipleDifferentTransports/VehicleTelemetryEventsConsumer.cs
+++ b/samples/MultipleDifferentTransports/VehicleTelemetryEventsConsumer.cs
@@ -1,7 +1,9 @@
-﻿using Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
+﻿using Tingle.EventBus.Configuration;
+using Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
 namespace MultipleDifferentTransports;
 
+[ConsumerName("$Default")] // or [ConsumerName(EventHubConsumerClient.DefaultConsumerGroupName)]
 internal class VehicleTelemetryEventsConsumer : IEventConsumer<VehicleTelemetryEvent>
 {
     private readonly ILogger logger;

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -270,7 +270,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
         // 2. The ConsumerGroup is set to $Default (this may be changed to support more)
         var isIotHub = reg.IsConfiguredAsIotHub();
         var eventHubName = isIotHub ? reg.GetIotHubEventHubName() : name;
-        var consumerGroup = isIotHub || Options.UseBasicTier ? EventHubConsumerClient.DefaultConsumerGroupName : ecr.ConsumerName;
+        var consumerGroup = Options.UseBasicTier ? EventHubConsumerClient.DefaultConsumerGroupName : ecr.ConsumerName;
 
         async Task<EventProcessorClient> creator(string key, CancellationToken ct)
         {


### PR DESCRIPTION
This PR removes the fixed use of `$Default` for consumers on events from the inbuilt EventHubs endpoint in Azure IoT Hub instances. It hence allows for different consumer groups for scenarios such as two applications reading from the same telemetry, one for archiving and another for immediate processing.