### PR TITLE
Remove SuffixConsumerName option

### DIFF
--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqConfigureOptions.cs
@@ -32,12 +32,6 @@ internal class RabbitMqConfigureOptions : EventBusTransportConfigureOptions<Rabb
             {
                 throw new NotSupportedException($"When using RabbitMQ transport '{nameof(BusOptions.Naming.UseFullTypeNames)}' must be 'true'");
             }
-
-            // consumer names must be suffixed
-            if (!BusOptions.Naming.SuffixConsumerName)
-            {
-                throw new NotSupportedException($"When using RabbitMQ transport '{nameof(BusOptions.Naming.SuffixConsumerName)}' must be 'true'");
-            }
         }
 
         // if we do not have a connection factory, attempt to create one

--- a/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
+++ b/src/Tingle.EventBus.Transports.RabbitMQ/RabbitMqTransport.cs
@@ -265,7 +265,8 @@ public class RabbitMqTransport : EventBusTransport<RabbitMqTransportOptions>, ID
             var exchangeName = reg.EventName!;
             foreach (var ecr in reg.Consumers.Values)
             {
-                var queueName = ecr.ConsumerName!;
+                // queue names must be unique so add the exchange name so that we can tell to whom the queue belongs
+                var queueName = BusOptions.Naming.Join(ecr.ConsumerName!, exchangeName);
 
                 var channel = await GetSubscriptionChannelAsync(exchangeName: exchangeName, queueName: queueName, cancellationToken).ConfigureAwait(false);
                 var consumer = new AsyncEventingBasicConsumer(channel);

--- a/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
+++ b/src/Tingle.EventBus/Configuration/DefaultEventConfigurator.cs
@@ -137,7 +137,6 @@ internal class DefaultEventConfigurator : IEventConfigurator
                         _ => throw new InvalidOperationException($"'{nameof(options.ConsumerNameSource)}.{options.ConsumerNameSource}' is not supported"),
                     };
                     name = options.ApplyNamingConvention(name);
-                    name = options.SuffixConsumerName ? options.Join(name, reg.EventName) : name; // Append the EventName to ensure it is unique
                     name = options.AppendScope(name);
                     name = options.ReplaceInvalidCharacters(name);
                 }

--- a/src/Tingle.EventBus/DependencyInjection/EventBusNamingOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusNamingOptions.cs
@@ -65,15 +65,6 @@ public class EventBusNamingOptions
     public string? ConsumerNamePrefix { get; set; }
 
     /// <summary>
-    /// Indicates if the consumer name generated should be suffixed with the event name.
-    /// Some transports require this value to be <see langword="true"/>.
-    /// Setting to false can reduce the length of the consumer name hence being useful in scenarios
-    /// where the transport allow same name for two consumers so long as they are for different events.
-    /// Defaults to <see langword="true"/>
-    /// </summary>
-    public bool SuffixConsumerName { get; set; } = true;
-
-    /// <summary>
     /// Gets the application name from <see cref="IHostEnvironment.ApplicationName"/>
     /// and applies the naming settings in this options.
     /// </summary>

--- a/src/Tingle.EventBus/DependencyInjection/EventBusNamingOptions.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusNamingOptions.cs
@@ -107,19 +107,33 @@ public class EventBusNamingOptions
 
     internal string AppendScope(string unscoped) => string.IsNullOrWhiteSpace(Scope) ? unscoped : Join(Scope, unscoped);
 
-    internal string Join(params string[] args)
+    /// <summary>
+    /// Concatenates all the elements of a string array,
+    /// using a separator defined by <see cref="Convention"/> between each element in lowercase.
+    /// </summary>
+    /// <param name="values">An array that contains the elements to concatenate.</param>
+    /// <returns>
+    /// A lowercase string that consists of the elements in <paramref name="values"/> delimited by a separator string
+    /// defined by <see cref="Convention"/>.
+    /// -or- <see cref="string.Empty"/> if <paramref name="values"/> has zero elements.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="values"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The length of the resulting string overflows the maximum allowed length (<see cref="int.MaxValue"/>).
+    /// </exception>
+    public string Join(params string[] values)
     {
-        if (args is null) throw new ArgumentNullException(nameof(args));
+        if (values is null) throw new ArgumentNullException(nameof(values));
 
         // remove nulls
-        args = args.Where(a => !string.IsNullOrWhiteSpace(a)).ToArray();
+        values = values.Where(a => !string.IsNullOrWhiteSpace(a)).ToArray();
 
-        return Convention switch
+        return (Convention switch
         {
-            NamingConvention.KebabCase => string.Join("-", args).ToLowerInvariant(),
-            NamingConvention.SnakeCase => string.Join("_", args).ToLowerInvariant(),
-            NamingConvention.DotCase => string.Join(".", args).ToLowerInvariant(),
+            NamingConvention.KebabCase => string.Join("-", values),
+            NamingConvention.SnakeCase => string.Join("_", values),
+            NamingConvention.DotCase => string.Join(".", values),
             _ => throw new InvalidOperationException($"'{nameof(NamingConvention)}.{Convention}' does not support joining"),
-        };
+        }).ToLowerInvariant();
     }
 }

--- a/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
+++ b/tests/Tingle.EventBus.Tests/Configurator/DefaultEventConfiguratorTests.cs
@@ -78,75 +78,65 @@ public class DefaultEventConfiguratorTests
 
     [Theory]
     // Full type names
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "test_consumer1_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.TypeName, NamingConvention.DotCase, "test.consumer1.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "app1.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "app1_test_consumer1_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "app1.test.consumer1.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "service1.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-test-consumer1-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_test_consumer1_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "service1.test.consumer1.test.event1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.TypeName, NamingConvention.DotCase, "test.consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.Prefix, NamingConvention.DotCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "app1_test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "app1.test.consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.Prefix, NamingConvention.DotCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "service1-test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "service1_test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "service1.test.consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.TypeName, NamingConvention.KebabCase,
+        "tingle-event-bus-tests-configurator-test-consumer1")]
 
     // Short type names
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.TypeName, NamingConvention.KebabCase,
-        "tingle-event-bus-tests-configurator-test-consumer1-tingle-event-bus-tests-configurator-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase,
-        "tingle_event_bus_tests_configurator_test_consumer1_tingle_event_bus_tests_configurator_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.TypeName, NamingConvention.DotCase,
-        "tingle.event.bus.tests.configurator.test.consumer1.tingle.event.bus.tests.configurator.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1-tingle-event-bus-tests-configurator-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1_tingle_event_bus_tests_configurator_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "app1.tingle.event.bus.tests.configurator.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
-        "app1-tingle-event-bus-tests-configurator-test-consumer1-tingle-event-bus-tests-configurator-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase,
-        "app1_tingle_event_bus_tests_configurator_test_consumer1_tingle_event_bus_tests_configurator_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase,
-        "app1.tingle.event.bus.tests.configurator.test.consumer1.tingle.event.bus.tests.configurator.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1-tingle-event-bus-tests-configurator-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1_tingle_event_bus_tests_configurator_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "service1.tingle.event.bus.tests.configurator.test.event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
-        "service1-tingle-event-bus-tests-configurator-test-consumer1-tingle-event-bus-tests-configurator-test-event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase,
-        "service1_tingle_event_bus_tests_configurator_test_consumer1_tingle_event_bus_tests_configurator_test_event1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase,
-        "service1.tingle.event.bus.tests.configurator.test.consumer1.tingle.event.bus.tests.configurator.test.event1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.TypeName, NamingConvention.KebabCase,
+        "tingle-event-bus-tests-configurator-test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.TypeName, NamingConvention.SnakeCase,
+        "tingle_event_bus_tests_configurator_test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.TypeName, NamingConvention.DotCase,
+        "tingle.event.bus.tests.configurator.test.consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.Prefix, NamingConvention.DotCase, "app1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
+        "app1-tingle-event-bus-tests-configurator-test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase,
+        "app1_tingle_event_bus_tests_configurator_test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase,
+        "app1.tingle.event.bus.tests.configurator.test.consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.Prefix, NamingConvention.DotCase, "service1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase,
+        "service1-tingle-event-bus-tests-configurator-test-consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase,
+        "service1_tingle_event_bus_tests_configurator_test_consumer1")]
+    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase,
+        "service1.tingle.event.bus.tests.configurator.test.consumer1")]
 
     // Overriden by attribute
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, true, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.KebabCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", true, ConsumerNameSource.Prefix, NamingConvention.DotCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, true, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
-
-    // Appending
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, "service1", false, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "test-consumer1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), false, null, false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "app1-test-consumer1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, false, ConsumerNameSource.TypeName, NamingConvention.KebabCase, "tingle-event-bus-tests-configurator-test-consumer1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, false, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "tingle_event_bus_tests_configurator_test_consumer1")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, null, false, ConsumerNameSource.TypeName, NamingConvention.DotCase, "tingle.event.bus.tests.configurator.test.consumer1")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, false, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
-    [InlineData(typeof(TestEvent1), typeof(TestConsumer1), true, "service1", true, ConsumerNameSource.TypeName, NamingConvention.KebabCase,
-        "tingle-event-bus-tests-configurator-test-consumer1-tingle-event-bus-tests-configurator-test-event1")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, ConsumerNameSource.TypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, null, ConsumerNameSource.Prefix, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), false, "service1", ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", ConsumerNameSource.TypeName, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", ConsumerNameSource.Prefix, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, "service1", ConsumerNameSource.Prefix, NamingConvention.DotCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.KebabCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.SnakeCase, "sample-consumer")]
+    [InlineData(typeof(TestEvent2), typeof(TestConsumer2), true, null, ConsumerNameSource.PrefixAndTypeName, NamingConvention.DotCase, "sample-consumer")]
     public void SetConsumerName_Works(Type eventType,
                                       Type consumerType,
                                       bool useFullTypeNames,
                                       string prefix,
-                                      bool suffixEventName,
                                       ConsumerNameSource consumerNameSource,
                                       NamingConvention namingConvention,
                                       string expected)
@@ -160,7 +150,6 @@ public class DefaultEventConfiguratorTests
         options.Naming.UseFullTypeNames = useFullTypeNames;
         options.Naming.ConsumerNameSource = consumerNameSource;
         options.Naming.ConsumerNamePrefix = prefix;
-        options.Naming.SuffixConsumerName = suffixEventName;
 
         var registration = new EventRegistration(eventType);
         registration.Consumers.Add(consumerType, new EventConsumerRegistration(consumerType));


### PR DESCRIPTION
This option is only useful for RabbitMQ hence the logic should be moved there.