### PR TITLE
Fix type for extensions data in JSON

### DIFF
--- a/samples/AzureIotHub/MyIotHubEvent.cs
+++ b/samples/AzureIotHub/MyIotHubEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
 namespace AzureIotHub;
@@ -19,5 +18,5 @@ public class MyIotHubTelemetry
     public DateTimeOffset Timestamp { get; set; }
 
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }

--- a/samples/AzureManagedIdentity/VehicleTelemetryEvent.cs
+++ b/samples/AzureManagedIdentity/VehicleTelemetryEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace AzureManagedIdentity;
 
@@ -15,7 +14,7 @@ internal class VehicleTelemetryEvent
     public VehicleDoorStatus? VehicleDoorStatus { get; set; }
 
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }
 
 public enum VehicleDoorStatus

--- a/samples/ConfigSample/VehicleDoorOpenedEvent.cs
+++ b/samples/ConfigSample/VehicleDoorOpenedEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace ConfigSample;
 
@@ -19,7 +18,7 @@ internal class VehicleTelemetryEvent
     public VehicleDoorKind? VehicleDoorKind { get; set; }
     public VehicleDoorStatus? VehicleDoorStatus { get; set; }
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }
 
 internal enum VehicleDoorStatus { Unknown, Open, Closed, }

--- a/samples/MultipleDifferentTransports/VehicleTelemetryEvent.cs
+++ b/samples/MultipleDifferentTransports/VehicleTelemetryEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 using Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
 namespace MultipleDifferentTransports;
@@ -24,7 +23,7 @@ internal class VehicleTelemetry
     public VehicleDoorStatus? VehicleDoorStatus { get; set; }
 
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }
 
 public enum VehicleDoorStatus

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubConnectionAuthMethod.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubConnectionAuthMethod.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
@@ -27,5 +26,5 @@ public record IotHubConnectionAuthMethod
 
     ///
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubOperationalEvent.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/IotHub/IotHubOperationalEvent.cs
@@ -1,5 +1,4 @@
-﻿using System.Text.Json.Nodes;
-using System.Text.Json.Serialization;
+﻿using System.Text.Json.Serialization;
 
 namespace Tingle.EventBus.Transports.Azure.EventHubs.IotHub;
 
@@ -53,7 +52,7 @@ public record IotHubDeviceLifecycleEvent: AbstractIotHubEvent
 {
     ///
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }
 
 /// <summary>
@@ -63,7 +62,7 @@ public record IotHubDeviceTwinChangeEvent : AbstractIotHubEvent
 {
     ///
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }
 
 /// <summary>
@@ -121,5 +120,5 @@ public record IotHubTwinProperties
 
     ///
     [JsonExtensionData]
-    public JsonObject? Extras { get; set; }
+    public Dictionary<string, object>? Extras { get; set; }
 }

--- a/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/IotHubEventSerializerTests.cs
+++ b/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/IotHubEventSerializerTests.cs
@@ -58,7 +58,7 @@ public class IotHubEventSerializerTests
             Assert.Null(envelope.Event.ConnectionStateEvent);
             var telemetry = Assert.IsType<MyIotHubTelemetry>(envelope.Event.Telemetry);
             Assert.Equal(DateTimeOffset.Parse("2022-12-22T12:10:51Z"), telemetry.Timestamp);
-            Assert.Equal(JsonSerializer.SerializeToNode(new { door = "frontLeft" })!.ToJsonString(), telemetry.Extras?.ToJsonString());
+            Assert.Equal(JsonSerializer.SerializeToNode(new { door = "frontLeft" })!.ToJsonString(), JsonSerializer.Serialize(telemetry.Extras));
         });
     }
 


### PR DESCRIPTION
Use `Dictionary<string, object>` instead of `JsonObject` for `Extras`/`ExtensionsData`. This solves an issue with subsequent serialization in samples or elsewhere. It is better to convert the whole deserialized object to a `JsonNode`/`JsonObject` if that is desired.