### PR TITLE
Better checkpointing for EventHubs and Kafka

### DIFF
--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -6,6 +6,7 @@ using Azure.Storage.Blobs;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Net.Mime;
 using Tingle.EventBus.Configuration;
@@ -22,6 +23,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
     private readonly EventBusConcurrentDictionary<(Type, bool), EventHubProducerClient> producersCache = new();
     private readonly EventBusConcurrentDictionary<string, EventProcessorClient> processorsCache = new();
     private readonly SemaphoreSlim blobContainerClientLock = new(1, 1); // only one at a time.
+    private readonly ConcurrentDictionary<string, int> checkpointingCounter = new();
     private BlobContainerClient? blobContainerClient;
 
     /// <summary>
@@ -445,14 +447,21 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
          * Update the checkpoint store if needed so that the app receives
          * only newer events the next time it's run.
         */
-        if ((data.SequenceNumber % Options.CheckpointInterval) == 0
-            && ShouldCheckpoint(successful, ecr.UnhandledErrorBehaviour))
+        if (CanCheckpoint(successful, ecr.UnhandledErrorBehaviour))
         {
-            Logger.Checkpointing(partition: args.Partition,
-                                 eventHubName: processor.EventHubName,
-                                 consumerGroup: processor.ConsumerGroup,
-                                 sequenceNumber: data.SequenceNumber);
-            await args.UpdateCheckpointAsync(args.CancellationToken).ConfigureAwait(false);
+            var counterKey = string.Join("|", processor.EventHubName, processor.ConsumerGroup, args.Partition.PartitionId);
+            var countSinceLast = checkpointingCounter.AddOrUpdate(key: counterKey,
+                                                                  addValue: 1,
+                                                                  updateValueFactory: (_, current) => current + 1);
+            if (countSinceLast >= Options.CheckpointInterval)
+            {
+                Logger.Checkpointing(partition: args.Partition,
+                                     eventHubName: processor.EventHubName,
+                                     consumerGroup: processor.ConsumerGroup,
+                                     sequenceNumber: data.SequenceNumber);
+                await args.UpdateCheckpointAsync(args.CancellationToken).ConfigureAwait(false);
+                checkpointingCounter[counterKey] = 0;
+            }
         }
     }
 
@@ -485,7 +494,7 @@ public class AzureEventHubsTransport : EventBusTransport<AzureEventHubsTransport
         return Task.CompletedTask;
     }
 
-    internal static bool ShouldCheckpoint(bool successful, UnhandledConsumerErrorBehaviour? behaviour)
+    internal static bool CanCheckpoint(bool successful, UnhandledConsumerErrorBehaviour? behaviour)
     {
         /*
          * We should only checkpoint if successful or we are discarding or dead-lettering.

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/ILoggerExtensions.cs
@@ -9,14 +9,14 @@ namespace Microsoft.Extensions.Logging;
 /// </summary>
 internal static partial class ILoggerExtensions
 {
-    [LoggerMessage(100, LogLevel.Information, "Opening processor for EventHub: {EventHubName}\r\nConsumerGroup: {ConsumerGroup}\r\nPartitionId: {PartitionId}\r\nDefaultStartingPosition: {Position}")]
+    [LoggerMessage(100, LogLevel.Information, "Opening processor for '{EventHubName}/{ConsumerGroup}', PartitionId: {PartitionId}. DefaultStartingPosition: {Position}")]
     public static partial void OpeningProcessor(this ILogger logger, string eventHubName, string consumerGroup, string partitionId, EventPosition position);
 
-    [LoggerMessage(101, LogLevel.Information, "Closing processor for EventHub: {EventHubName}\r\nConsumerGroup: {ConsumerGroup}\r\nPartitionId: {PartitionId} (Reason: {Reason})")]
+    [LoggerMessage(101, LogLevel.Information, "Closing processor for '{EventHubName}/{ConsumerGroup}', PartitionId: {PartitionId}. Reason: {Reason}")]
     public static partial void ClosingProcessor(this ILogger logger, string eventHubName, string consumerGroup, string partitionId, ProcessingStoppedReason reason);
 
-    [LoggerMessage(102, LogLevel.Error, "Event processing faulted. Operation: {Operation}\r\nEventHub: {EventHubName}\r\nConsumerGroup: {ConsumerGroup}\r\nPartitionId: {PartitionId}")]
-    public static partial void ProcessingError(this ILogger logger, string operation, string eventHubName, string consumerGroup, string partitionId, Exception ex);
+    [LoggerMessage(102, LogLevel.Error, "Event processing faulted for '{EventHubName}/{ConsumerGroup}', PartitionId: {PartitionId}. Operation: {Operation}")]
+    public static partial void ProcessingError(this ILogger logger, string eventHubName, string consumerGroup, string partitionId, string operation, Exception ex);
 
     [LoggerMessage(103, LogLevel.Debug, "Stopping processor: {Processor}.")]
     public static partial void StoppingProcessor(this ILogger logger, string processor);
@@ -26,6 +26,9 @@ internal static partial class ILoggerExtensions
 
     [LoggerMessage(105, LogLevel.Warning, "Stop processor faulted for {Processor}.")]
     public static partial void StopProcessorFaulted(this ILogger logger, string processor, Exception ex);
+
+    [LoggerMessage(106, LogLevel.Information, "Checkpointing event processing at '{BlobContainerUri}'")]
+    public static partial void CheckpointStore(this ILogger logger, Uri blobContainerUri);
 
 
     [LoggerMessage(200, LogLevel.Warning, "Azure EventHubs does not support delay or scheduled publish.")]
@@ -56,16 +59,16 @@ internal static partial class ILoggerExtensions
         logger.SendingEvents(events.Select(e => e.Id).ToList(), eventHubName, scheduled);
     }
 
-    [LoggerMessage(204, LogLevel.Debug, "Checkpointing {Partition} of '{EventHubName}/{ConsumerGroup}' at {SequenceNumber}.")]
-    public static partial void Checkpointing(this ILogger logger, PartitionContext partition, string eventHubName, string consumerGroup, long sequenceNumber);
+    [LoggerMessage(204, LogLevel.Debug, "Checkpointing '{EventHubName}/{ConsumerGroup}', PartitionId: '{PartitionId}' at '{SequenceNumber}'")]
+    public static partial void Checkpointing(this ILogger logger, string eventHubName, string consumerGroup, string partitionId, long sequenceNumber);
 
 
-    [LoggerMessage(300, LogLevel.Debug, "Processor received event on EventHub: {EventHubName}\r\nConsumerGroup: {ConsumerGroup}\r\nPartitionId: {PartitionId}")]
+    [LoggerMessage(300, LogLevel.Debug, "Processor received event from '{EventHubName}/{ConsumerGroup}', PartitionId: '{PartitionId}'")]
     public static partial void ProcessorReceivedEvent(this ILogger logger, string eventHubName, string consumerGroup, string partitionId);
 
-    [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EventHubName}/{ConsumerGroup}'.\r\nPartitionKey: {PartitionKey}\r\nSequenceNumber: {SequenceNumber}'")]
-    public static partial void ProcessingEvent(this ILogger logger, string messageId, string eventHubName, string consumerGroup, string partitionKey, long sequenceNumber);
+    [LoggerMessage(301, LogLevel.Debug, "Processing '{MessageId}' from '{EventHubName}/{ConsumerGroup}', PartitionId: '{PartitionId}'. PartitionKey: '{PartitionKey}' SequenceNumber: '{SequenceNumber}'")]
+    public static partial void ProcessingEvent(this ILogger logger, string messageId, string eventHubName, string consumerGroup, string partitionId, string? partitionKey, long sequenceNumber);
 
-    [LoggerMessage(302, LogLevel.Information, "Received event: '{EventBusId}' from '{EventHubName}/{ConsumerGroup}'.\r\nPartitionKey: {PartitionKey}\r\nSequenceNumber: {SequenceNumber}'")]
-    public static partial void ReceivedEvent(this ILogger logger, string? eventBusId, string eventHubName, string consumerGroup, string partitionKey, long sequenceNumber);
+    [LoggerMessage(302, LogLevel.Information, "Received event: '{EventBusId}' from '{EventHubName}/{ConsumerGroup}', PartitionId: '{PartitionId}'. PartitionKey: '{PartitionKey}' SequenceNumber: '{SequenceNumber}'")]
+    public static partial void ReceivedEvent(this ILogger logger, string? eventBusId, string eventHubName, string consumerGroup, string partitionId, string? partitionKey, long sequenceNumber);
 }

--- a/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/AzureEventHubsTransportTests.cs
+++ b/tests/Tingle.EventBus.Transports.Azure.EventHubs.Tests/AzureEventHubsTransportTests.cs
@@ -11,9 +11,9 @@ public class AzureEventHubsTransportTests
     [InlineData(false, null, false)]
     [InlineData(false, UnhandledConsumerErrorBehaviour.Deadletter, true)]
     [InlineData(false, UnhandledConsumerErrorBehaviour.Discard, true)]
-    public void ShouldCheckpoint_Works(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool expected)
+    public void CanCheckpoint_Works(bool successful, UnhandledConsumerErrorBehaviour? behaviour, bool expected)
     {
-        var actual = AzureEventHubsTransport.ShouldCheckpoint(successful, behaviour);
+        var actual = AzureEventHubsTransport.CanCheckpoint(successful, behaviour);
         Assert.Equal(expected, actual);
     }
 }


### PR DESCRIPTION
Changed the checkpointing to be based on the number of processed events and not the `SequenceNumber` for EventHubs or `Offset` for Kafaka. Also updated the logs for EventBubs transport.