### PR TITLE
Update logging metadata to include entity URIs and FQDNs

### DIFF
--- a/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Amazon.Sqs/AmazonSqsTransport.cs
@@ -395,7 +395,7 @@ public class AmazonSqsTransport : EventBusTransport<AmazonSqsTransportOptions>, 
                                                           sequenceNumber: sequenceNumber,
                                                           extras: new Dictionary<string, string?>
                                                           {
-                                                              ["QueueUrl"] = queueUrl,
+                                                              [MetadataNames.EntityUri] = queueUrl,
                                                               ["ReceiptHandle"] = message.ReceiptHandle,
                                                               [nameof(message.MD5OfBody)] = message.MD5OfBody,
                                                               [nameof(message.MD5OfMessageAttributes)] = message.MD5OfMessageAttributes,

--- a/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.EventHubs/AzureEventHubsTransport.cs
@@ -362,11 +362,12 @@ public class AzureEventHubsTransport(IServiceScopeFactory serviceScopeFactory,
                                                           sequenceNumber: data.SequenceNumber.ToString(),
                                                           extras: new Dictionary<string, string?>
                                                           {
+                                                              [MetadataNames.FullyQualifiedNamespace] = processor.FullyQualifiedNamespace,
                                                               [MetadataNames.EventName] = eventName?.ToString(),
                                                               [MetadataNames.EventType] = eventType?.ToString(),
-                                                              ["PartitionId"] = partitionId,
                                                               ["EventHubName"] = processor.EventHubName,
                                                               ["ConsumerGroup"] = processor.ConsumerGroup,
+                                                              ["PartitionId"] = partitionId,
                                                               ["PartitionKey"] = data.PartitionKey,
                                                           });
 

--- a/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.QueueStorage/AzureQueueStorageTransport.cs
@@ -291,6 +291,7 @@ public class AzureQueueStorageTransport : EventBusTransport<AzureQueueStorageTra
                                                           correlationId: null,
                                                           extras: new Dictionary<string, string?>
                                                           {
+                                                              [MetadataNames.EntityUri] = queueClient.Uri.ToString(),
                                                               ["PopReceipt"] = message.PopReceipt,
                                                           });
 

--- a/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
+++ b/src/Tingle.EventBus.Transports.Azure.ServiceBus/AzureServiceBusTransport.cs
@@ -499,6 +499,7 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
 
     private async Task OnMessageReceivedAsync(EventRegistration reg, EventConsumerRegistration ecr, ServiceBusProcessor processor, ProcessMessageEventArgs args)
     {
+        var fqdn = args.FullyQualifiedNamespace;
         var entityPath = args.EntityPath;
         var message = args.Message;
         var messageId = message.MessageId;
@@ -511,7 +512,8 @@ public class AzureServiceBusTransport : EventBusTransport<AzureServiceBusTranspo
                                                           sequenceNumber: message.SequenceNumber.ToString(),
                                                           extras: new Dictionary<string, string?>
                                                           {
-                                                              ["EntityPath"] = entityPath,
+                                                              [MetadataNames.FullyQualifiedNamespace] = fqdn,
+                                                              [MetadataNames.EntityUri] = entityPath,
                                                               ["EnqueuedSequenceNumber"] = message.EnqueuedSequenceNumber.ToString(),
                                                           });
 

--- a/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
+++ b/src/Tingle.EventBus.Transports.InMemory/InMemoryTransport.cs
@@ -323,7 +323,7 @@ public class InMemoryTransport(IServiceScopeFactory serviceScopeFactory,
                                                           sequenceNumber: message.SequenceNumber.ToString(),
                                                           extras: new Dictionary<string, string?>
                                                           {
-                                                              ["EntityPath"] = entityPath,
+                                                              [MetadataNames.EntityUri] = entityPath,
                                                           });
 
         // Instrumentation

--- a/src/Tingle.EventBus/MetadataNames.cs
+++ b/src/Tingle.EventBus/MetadataNames.cs
@@ -13,6 +13,8 @@ public static class MetadataNames
     public const string CorrelationId = "CorrelationId";
     public const string RequestId = "RequestId";
     public const string InitiatorId = "InitiatorId";
+    public const string FullyQualifiedNamespace = "FullyQualifiedNamespace";
+    public const string EntityUri = "EntityUri";
 
     public const string ActivityId = "EventBus.ActivityId";
     public const string EventType = "EventBus.EventType";


### PR DESCRIPTION
This allows one to disambiguate logs from multiple transports. For example, events from multiple Azure Service Bus namespaces but the queues are named the same such as when copying or fanning-out to multiple tenants.