### PR TITLE
Drop net6 and net7, which are EoL and target net9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.x
+        dotnet-version: 9.x
 
     - name: Install dependencies
       run: dotnet restore
@@ -99,7 +99,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '9.x'
         source-url: "https://pkgs.dev.azure.com/tingle/_packaging/tingle/nuget/v3/index.json"
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.PRIVATE_FEED_API_KEY }}
@@ -125,7 +125,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '8.x'
+        dotnet-version: '9.x'
         source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
     - name: Setup .NET SDK
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 8.x
+        dotnet-version: 9.x
         source-url: https://api.nuget.org/v3/index.json
       env:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <!-- There is nothing else to import. -->
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,12 +3,12 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., '$(MSBuildThisFileName)$(MSBuildThisFileExtension)'))\$(MSBuildThisFileName)$(MSBuildThisFileExtension)" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.1;net8.0;net9.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Deterministic>true</Deterministic>
     <Authors>Tingle Software</Authors>
     <Company>Tingle Software</Company>
-    <IsAotCompatible>true</IsAotCompatible>
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">true</IsAotCompatible>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventConsumerRegistration.cs
@@ -100,6 +100,7 @@ public class EventConsumerRegistration : IEquatable<EventConsumerRegistration?>
     /// <param name="consumerType">The type of consumer.</param>
     /// <param name="deadletter">Indicates if the consumer should be connected to the dead-letter entity.</param>
     [RequiresDynamicCode(MessageStrings.GenericsDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public static EventConsumerRegistration Create([DynamicallyAccessedMembers(TrimmingHelper.Event)] Type eventType, [DynamicallyAccessedMembers(TrimmingHelper.Consumer)] Type consumerType, bool deadletter)
         => new(consumerType, deadletter, ExecutionHelper.MakeDelegate(eventType, consumerType));
 

--- a/src/Tingle.EventBus/Configuration/EventRegistration.cs
+++ b/src/Tingle.EventBus/Configuration/EventRegistration.cs
@@ -105,6 +105,7 @@ public class EventRegistration : IEquatable<EventRegistration?>
     /// <summary>Create a new instance of <see cref="EventRegistration"/> for the specified event type.</summary>
     /// <param name="eventType">The type of event.</param>
     [RequiresDynamicCode(MessageStrings.GenericsDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public static EventRegistration Create([DynamicallyAccessedMembers(TrimmingHelper.Event)] Type eventType) => new(eventType, ExecutionHelper.MakeDelegate(eventType));
 
     #region Equality Overrides

--- a/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
+++ b/src/Tingle.EventBus/DependencyInjection/EventBusBuilder.cs
@@ -236,6 +236,7 @@ public class EventBusBuilder
     /// <param name="configure"></param>
     /// <returns></returns>
     [RequiresDynamicCode(ConsumersRequiresDynamicCode)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public EventBusBuilder AddConsumer<[DynamicallyAccessedMembers(TrimmingHelper.Consumer)] TConsumer>(
         Action<EventRegistration, EventConsumerRegistration> configure) where TConsumer : class, IEventConsumer
     {
@@ -322,6 +323,7 @@ public class EventBusBuilder
     /// <param name="configure"></param>
     /// <returns></returns>
     [RequiresDynamicCode(ConsumersRequiresDynamicCode)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public EventBusBuilder AddConsumer<[DynamicallyAccessedMembers(TrimmingHelper.Consumer)] TConsumer>(
         Action<EventConsumerRegistration>? configure = null) where TConsumer : class, IEventConsumer
     {

--- a/src/Tingle.EventBus/Internal/ExecutionHelper.cs
+++ b/src/Tingle.EventBus/Internal/ExecutionHelper.cs
@@ -53,6 +53,7 @@ internal static class ExecutionHelper
     }
 
     [RequiresDynamicCode(MessageStrings.GenericsDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public static DeserializerDelegate MakeDelegate([DynamicallyAccessedMembers(TrimmingHelper.Event)] Type eventType)
     {
         var flags = System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public;
@@ -62,6 +63,7 @@ internal static class ExecutionHelper
     }
 
     [RequiresDynamicCode(MessageStrings.GenericsDynamicCodeMessage)]
+    [RequiresUnreferencedCode(MessageStrings.GenericsUnreferencedCodeMessage)]
     public static ConsumeDelegate MakeDelegate([DynamicallyAccessedMembers(TrimmingHelper.Event)] Type eventType, [DynamicallyAccessedMembers(TrimmingHelper.Consumer)] Type consumerType)
     {
         var flags = System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Public;

--- a/src/Tingle.EventBus/MessageStrings.cs
+++ b/src/Tingle.EventBus/MessageStrings.cs
@@ -13,5 +13,6 @@ internal class MessageStrings
     public const string RequiresUnreferencedCodeMessage = "JSON serialization, deserialization, and binding strongly typed objects to configuration values might require types that cannot be statically analyzed.";
     public const string RequiresDynamicCodeMessage = "JSON serialization, deserialization, and binding strongly typed objects to configuration values might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.";
 
-    public const string GenericsDynamicCodeMessage = "The native code for this instantiation might not be available at runtime";
+    public const string GenericsUnreferencedCodeMessage = "The native code for this instantiation might require types that cannot be statically analyzed.";
+    public const string GenericsDynamicCodeMessage = "The native code for this instantiation might not be available at runtime.";
 }


### PR DESCRIPTION
.NET 6 reached the end of life on November 12, 2024 while .NET 7 reached the end of life on May 14, 2024. This PR removes support for them and adds support for .NET 9 was added.

Some additional checks and annotations for trimming/AoT were added.